### PR TITLE
Rewrite search to use Reciprocal Rank Fusion (RRF)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,10 @@ There are three codebases:
 - `cosma` (root)
 
 ## Testing
-- Run tests with `uv run pytest`
+- Run all tests: `uv run pytest`
+- For cosma-backend specifically: `cd packages/cosma-backend && uv run --group test pytest --no-cov`
+- Run unit tests only: `uv run --group test pytest tests/unit/ -m unit --no-cov`
+- Run integration tests only: `uv run --group test pytest tests/integration/ -m integration --no-cov`
 
 ## Development
 

--- a/packages/cosma-backend/src/cosma_backend/db/database.py
+++ b/packages/cosma-backend/src/cosma_backend/db/database.py
@@ -551,7 +551,7 @@ class Database:
             
             return watched_dir
 
-    async def keyword_search(self, query: str, limit: int = 20, directory: str | None = None) -> list[tuple[File, float]]:
+    async def keyword_search(self, query: str, limit: int = 20, directory: str | None = None, allow_operators: bool = False) -> list[tuple[File, float]]:
         """
         Perform keyword search using FTS5 with BM25 ranking.
 
@@ -559,12 +559,18 @@ class Database:
             query: Search query
             limit: Maximum number of results
             directory: Optional directory path to limit search scope
+            allow_operators: If True, preserve AND/OR/NOT operators
 
         Returns:
             List of tuples (File, relevance_score)
         """
-        
-        sanitized_query = f'"{query.replace('"', '""')}"'
+        # Import here to avoid circular import
+        from cosma_backend.searcher.fts5_query import parse_fts5_query
+
+        sanitized_query = parse_fts5_query(query, allow_operators=allow_operators)
+        if not sanitized_query:
+            return []
+
         logger.debug(sm("Performing keyword search", query=sanitized_query, limit=limit, directory=directory))
 
         # FTS5 query with BM25 ranking
@@ -610,6 +616,67 @@ class Database:
 
             logger.info(sm("Keyword search completed", count=len(results)))
             return results
+
+    async def get_fts5_suggestions(self, prefix: str, limit: int = 10) -> list[str]:
+        """
+        Get autocomplete suggestions using FTS5 prefix matching.
+
+        Args:
+            prefix: Search prefix
+            limit: Maximum number of suggestions
+
+        Returns:
+            List of suggested terms (filenames and titles matching the prefix)
+        """
+        # Import here to avoid circular import
+        from cosma_backend.searcher.fts5_query import build_prefix_query
+
+        fts5_query = build_prefix_query(prefix)
+        if not fts5_query:
+            return []
+
+        logger.debug(sm("Getting FTS5 suggestions", prefix=prefix, fts5_query=fts5_query))
+
+        SQL = """
+        SELECT DISTINCT f.filename, f.title
+        FROM files_fts fts
+        JOIN files f ON f.id = fts.rowid
+        WHERE files_fts MATCH ?
+        ORDER BY rank
+        LIMIT ?
+        """
+
+        async with self.acquire() as conn:
+            try:
+                rows = await conn.fetchall(SQL, (fts5_query, limit * 2))
+            except Exception as e:
+                logger.warning(sm("FTS5 suggestions query failed", error=str(e), prefix=prefix))
+                return []
+
+            suggestions = []
+            prefix_lower = prefix.lower()
+
+            for row in rows:
+                # Add filename if it matches prefix
+                filename = row["filename"]
+                if filename and filename.lower().startswith(prefix_lower):
+                    suggestions.append(filename)
+
+                # Add title words that match prefix
+                title = row["title"]
+                if title:
+                    for word in title.split():
+                        if word.lower().startswith(prefix_lower) and len(word) > 2:
+                            suggestions.append(word)
+
+                if len(suggestions) >= limit:
+                    break
+
+            # Deduplicate and limit
+            unique_suggestions = list(dict.fromkeys(suggestions))[:limit]
+
+            logger.debug(sm("Generated FTS5 suggestions", count=len(unique_suggestions)))
+            return unique_suggestions
 
     async def update_file_timestamp(self, file_path: str) -> bool:
         """

--- a/packages/cosma-backend/src/cosma_backend/searcher/fts5_query.py
+++ b/packages/cosma-backend/src/cosma_backend/searcher/fts5_query.py
@@ -1,0 +1,124 @@
+"""
+FTS5 query parsing and sanitization for safe full-text search queries.
+"""
+
+import re
+
+# FTS5 special characters that need escaping
+FTS5_SPECIAL_CHARS = set('"*():^')
+
+
+def escape_fts5_token(token: str) -> str:
+    """
+    Escape special FTS5 characters in a token.
+
+    FTS5 treats the following as special: " * ( ) : ^
+    We escape by wrapping the token in double quotes and escaping internal quotes.
+
+    Args:
+        token: Raw search token
+
+    Returns:
+        Escaped token safe for FTS5 queries
+    """
+    if not token:
+        return ""
+
+    # Escape internal double quotes by doubling them
+    escaped = token.replace('"', '""')
+
+    # Wrap in double quotes to treat as literal
+    return f'"{escaped}"'
+
+
+def parse_fts5_query(query: str, allow_operators: bool = False) -> str:
+    """
+    Parse user query into safe FTS5 syntax.
+
+    By default, treats all input as literal search terms (no operators).
+    When allow_operators=True, preserves AND, OR, NOT operators.
+
+    Args:
+        query: Raw user search query
+        allow_operators: If True, preserve boolean operators
+
+    Returns:
+        Sanitized FTS5 query string
+    """
+    if not query or not query.strip():
+        return ""
+
+    query = query.strip()
+
+    if allow_operators:
+        return _parse_with_operators(query)
+    else:
+        return _parse_literal(query)
+
+
+def _parse_literal(query: str) -> str:
+    """
+    Parse query as literal search terms, escaping all special characters.
+
+    Splits on whitespace and treats each word as a literal token.
+    """
+    # Split on whitespace
+    tokens = query.split()
+
+    if not tokens:
+        return ""
+
+    # Escape each token and join with spaces (implicit AND in FTS5)
+    escaped_tokens = [escape_fts5_token(token) for token in tokens if token]
+
+    return " ".join(escaped_tokens)
+
+
+def _parse_with_operators(query: str) -> str:
+    """
+    Parse query preserving AND, OR, NOT operators.
+
+    Operators must be uppercase to be recognized.
+    Non-operator terms are escaped.
+    """
+    # FTS5 boolean operators (case-sensitive, must be uppercase)
+    operators = {"AND", "OR", "NOT"}
+
+    # Simple tokenization - split on whitespace while preserving operators
+    tokens = query.split()
+
+    if not tokens:
+        return ""
+
+    result_parts = []
+
+    for token in tokens:
+        if token in operators:
+            result_parts.append(token)
+        else:
+            result_parts.append(escape_fts5_token(token))
+
+    return " ".join(result_parts)
+
+
+def build_prefix_query(prefix: str) -> str:
+    """
+    Build an FTS5 prefix search query.
+
+    Args:
+        prefix: Search prefix
+
+    Returns:
+        FTS5 query for prefix matching (e.g., 'test*')
+    """
+    if not prefix or not prefix.strip():
+        return ""
+
+    # Clean the prefix - remove special chars and whitespace
+    cleaned = re.sub(r'["\*\(\)\:\^\s]+', "", prefix.strip())
+
+    if not cleaned:
+        return ""
+
+    # FTS5 prefix search uses * suffix
+    return f'"{cleaned}"*'

--- a/packages/cosma-backend/src/cosma_backend/searcher/rrf.py
+++ b/packages/cosma-backend/src/cosma_backend/searcher/rrf.py
@@ -1,0 +1,116 @@
+"""
+Reciprocal Rank Fusion (RRF) implementation for combining ranked search results.
+
+RRF is a method for combining multiple ranked lists that doesn't require score
+normalization. It works by assigning each item a score based on its rank in each
+list: score = 1 / (k + rank), then summing across all lists.
+
+Reference: Cormack, Gordon V., Charles LA Clarke, and Stefan Buettcher.
+"Reciprocal rank fusion outperforms condorcet and individual rank learning methods."
+SIGIR 2009.
+"""
+
+from typing import TypeVar, Hashable
+
+T = TypeVar("T")
+
+
+def compute_rrf_scores(
+    ranked_lists: list[list[tuple[Hashable, T]]],
+    k: int = 60
+) -> dict[Hashable, float]:
+    """
+    Compute RRF scores for items across multiple ranked lists.
+
+    RRF score = sum(1 / (k + rank)) for each ranking system where the item appears.
+    Items appearing in multiple lists get higher scores.
+
+    Args:
+        ranked_lists: List of ranked lists, where each list contains (id, data) tuples
+                     ordered by rank (best first, 0-indexed)
+        k: Smoothing constant (default 60, commonly used value)
+
+    Returns:
+        Dictionary mapping item IDs to their RRF scores
+    """
+    scores: dict[Hashable, float] = {}
+
+    for ranked_list in ranked_lists:
+        for rank, (item_id, _data) in enumerate(ranked_list):
+            # RRF formula: 1 / (k + rank)
+            # rank is 0-indexed, so first item gets 1/(k+0) = 1/k
+            rrf_contribution = 1.0 / (k + rank)
+            scores[item_id] = scores.get(item_id, 0.0) + rrf_contribution
+
+    return scores
+
+
+def merge_with_rrf(
+    semantic_results: list[tuple[Hashable, T, float]],
+    keyword_results: list[tuple[Hashable, T, float]],
+    k: int = 60
+) -> list[tuple[Hashable, T, float, str, int | None, int | None]]:
+    """
+    Merge semantic and keyword search results using Reciprocal Rank Fusion.
+
+    Args:
+        semantic_results: List of (id, data, score) tuples from semantic search,
+                         ordered by relevance (best first)
+        keyword_results: List of (id, data, score) tuples from keyword search,
+                        ordered by relevance (best first)
+        k: RRF smoothing constant (default 60)
+
+    Returns:
+        List of (id, data, rrf_score, match_type, semantic_rank, keyword_rank) tuples,
+        sorted by RRF score descending.
+
+        match_type is one of: "hybrid", "semantic", "keyword"
+    """
+    # Build ranked lists for RRF computation
+    semantic_ranked = [(item_id, data) for item_id, data, _score in semantic_results]
+    keyword_ranked = [(item_id, data) for item_id, data, _score in keyword_results]
+
+    # Compute RRF scores
+    rrf_scores = compute_rrf_scores([semantic_ranked, keyword_ranked], k=k)
+
+    # Build lookup maps for data and ranks
+    semantic_data: dict[Hashable, T] = {}
+    semantic_ranks: dict[Hashable, int] = {}
+    for rank, (item_id, data, _score) in enumerate(semantic_results):
+        semantic_data[item_id] = data
+        semantic_ranks[item_id] = rank
+
+    keyword_data: dict[Hashable, T] = {}
+    keyword_ranks: dict[Hashable, int] = {}
+    for rank, (item_id, data, _score) in enumerate(keyword_results):
+        keyword_data[item_id] = data
+        keyword_ranks[item_id] = rank
+
+    # Build merged results
+    merged: list[tuple[Hashable, T, float, str, int | None, int | None]] = []
+
+    for item_id, rrf_score in rrf_scores.items():
+        # Get data from whichever source has it (prefer semantic for completeness)
+        data = semantic_data.get(item_id) or keyword_data.get(item_id)
+
+        # Determine match type
+        in_semantic = item_id in semantic_data
+        in_keyword = item_id in keyword_data
+
+        if in_semantic and in_keyword:
+            match_type = "hybrid"
+        elif in_semantic:
+            match_type = "semantic"
+        else:
+            match_type = "keyword"
+
+        # Get ranks (None if not in that list)
+        sem_rank = semantic_ranks.get(item_id)
+        kw_rank = keyword_ranks.get(item_id)
+
+        merged.append((item_id, data, rrf_score, match_type, sem_rank, kw_rank))
+
+    # Sort by RRF score descending
+    merged.sort(key=lambda x: x[2], reverse=True)
+
+    return merged

--- a/packages/cosma-backend/src/cosma_backend/searcher/searcher.py
+++ b/packages/cosma-backend/src/cosma_backend/searcher/searcher.py
@@ -17,6 +17,7 @@ from cosma_backend.db.database import Database
 from cosma_backend.embedder.embedder import AutoEmbedder
 from cosma_backend.logging import sm
 from cosma_backend.models import File
+from cosma_backend.searcher.rrf import merge_with_rrf
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -30,29 +31,15 @@ class SearchError(Exception):
 class SearchResult:
     """
     Represents a search result with metadata and scoring.
+
+    Scores are computed using Reciprocal Rank Fusion (RRF) which combines
+    rankings from multiple search methods without requiring score normalization.
     """
     file_metadata: File
-    semantic_score: float | None = None  # Distance from semantic search (lower is better)
-    keyword_score: float | None = None   # Keyword match score (higher is better)
-    combined_score: float = 0.0             # Combined weighted score
+    combined_score: float = 0.0             # RRF score (set by searcher)
     match_type: str = "unknown"             # Type of match: semantic, keyword, hybrid
-
-    def __post_init__(self):
-        """Calculate combined score after initialization."""
-        if self.semantic_score is not None and self.keyword_score is not None:
-            self.match_type = "hybrid"
-            # Normalize semantic score (convert distance to similarity)
-            semantic_similarity = max(0, 1 - self.semantic_score)
-            # Combine with weights (adjust as needed)
-            self.combined_score = (0.7 * semantic_similarity) + (0.3 * self.keyword_score)
-        elif self.semantic_score is not None:
-            self.match_type = "semantic"
-            self.combined_score = max(0, 1 - self.semantic_score)
-        elif self.keyword_score is not None:
-            self.match_type = "keyword"
-            self.combined_score = self.keyword_score
-        else:
-            self.combined_score = 0.0
+    semantic_rank: int | None = None        # Rank in semantic results (for debugging)
+    keyword_rank: int | None = None         # Rank in keyword results (for debugging)
     
     def to_json(self) -> dict:
         """
@@ -64,10 +51,10 @@ class SearchResult:
         return {
             "file_path": str(self.file_metadata.path),
             "filename": str(self.file_metadata.filename),
-            "semantic_score": self.semantic_score,
-            "keyword_score": self.keyword_score,
             "combined_score": self.combined_score,
-            "match_type": self.match_type
+            "match_type": self.match_type,
+            "semantic_rank": self.semantic_rank,
+            "keyword_rank": self.keyword_rank,
         }
 
 
@@ -88,136 +75,92 @@ class HybridSearcher:
         self.embedder = embedder or AutoEmbedder()
         logger.info(sm("HybridSearcher initialized"))
 
-    async def search(self,
-                    query: str,
-                    limit: int = 20,
-                    semantic_weight: float = 0.7,
-                    keyword_weight: float = 0.3,
-                    semantic_threshold: float = 2.0,
-                    include_metadata: bool = True,
-                    directory: str | None = None) -> list[SearchResult]:
+    async def search(
+        self,
+        query: str,
+        limit: int = 20,
+        semantic_weight: float = 0.7,  # Deprecated, kept for backward compatibility
+        keyword_weight: float = 0.3,   # Deprecated, kept for backward compatibility
+        semantic_threshold: float = 2.0,
+        include_metadata: bool = True,
+        directory: str | None = None,
+        rrf_k: int = 60,
+    ) -> list[SearchResult]:
         """
-        Perform hybrid search combining semantic and keyword matching.
+        Perform hybrid search combining semantic and keyword matching using RRF.
+
+        Uses Reciprocal Rank Fusion (RRF) to combine results from semantic and
+        keyword search. RRF is rank-based and doesn't require score normalization.
 
         Args:
             query: Search query
             limit: Maximum number of results
-            semantic_weight: Weight for semantic similarity (0-1)
-            keyword_weight: Weight for keyword matching (0-1)
+            semantic_weight: Deprecated, ignored (kept for backward compatibility)
+            keyword_weight: Deprecated, ignored (kept for backward compatibility)
             semantic_threshold: Maximum distance for semantic matches
             include_metadata: Include file metadata in results
             directory: Optional directory path to limit search scope
+            rrf_k: RRF smoothing constant (default 60)
 
         Returns:
-            List of SearchResult objects sorted by combined score
+            List of SearchResult objects sorted by RRF score
         """
-        logger.info(sm("Performing hybrid search",
+        logger.info(sm("Performing hybrid search with RRF",
                        query=query,
                        limit=limit,
-                       semantic_weight=semantic_weight,
-                       keyword_weight=keyword_weight,
+                       rrf_k=rrf_k,
                        directory=directory))
 
-        # Normalize weights
-        total_weight = semantic_weight + keyword_weight
-        if total_weight > 0:
-            semantic_weight /= total_weight
-            keyword_weight /= total_weight
+        # Fetch more results than needed - RRF benefits from larger candidate pools
+        fetch_limit = limit * 3
 
         # Collect results from both search methods
-        semantic_results = {}
-        keyword_results = {}
+        semantic_list: list[tuple[int, File, float]] = []
+        keyword_list: list[tuple[int, File, float]] = []
 
         # 1. Semantic search
         try:
-            semantic_matches = await self._semantic_search(query, limit * 2, semantic_threshold, directory)
+            semantic_matches = await self._semantic_search(query, fetch_limit, semantic_threshold, directory)
             for file_metadata, distance in semantic_matches:
                 file_id = file_metadata.id if hasattr(file_metadata, "id") else hash(file_metadata.file_path)
-                semantic_results[file_id] = (file_metadata, distance)
+                semantic_list.append((file_id, file_metadata, distance))
 
-            logger.debug(sm("Semantic search completed", results=len(semantic_results)))
+            logger.debug(sm("Semantic search completed", results=len(semantic_list)))
         except Exception as e:
             logger.warning(sm("Semantic search failed", error=str(e)))
 
         # 2. Keyword search
         try:
-            keyword_matches = await self._keyword_search(query, limit * 2, directory)
+            keyword_matches = await self._keyword_search(query, fetch_limit, directory)
             for file_metadata, score in keyword_matches:
                 file_id = file_metadata.id if hasattr(file_metadata, "id") else hash(file_metadata.file_path)
-                keyword_results[file_id] = (file_metadata, score)
+                keyword_list.append((file_id, file_metadata, score))
 
-            logger.debug(sm("Keyword search completed", results=len(keyword_results)))
+            logger.debug(sm("Keyword search completed", results=len(keyword_list)))
         except Exception as e:
             logger.warning(sm("Keyword search failed", error=str(e)))
 
-        # 3. Combine results
-        combined_results = []
-        all_file_ids = set(semantic_results.keys()) | set(keyword_results.keys())
+        # 3. Merge using RRF
+        merged = merge_with_rrf(semantic_list, keyword_list, k=rrf_k)
 
-        for file_id in all_file_ids:
-            semantic_data = semantic_results.get(file_id)
-            keyword_data = keyword_results.get(file_id)
-
-            # Get file metadata (prefer from semantic search for completeness)
-            if semantic_data:
-                file_metadata = semantic_data[0]
-                semantic_score = semantic_data[1]
-            else:
-                file_metadata = keyword_data[0]
-                semantic_score = None
-
-            keyword_score = keyword_data[1] if keyword_data else None
-
-            # Create search result
+        # 4. Build SearchResult objects
+        results = []
+        for file_id, file_metadata, rrf_score, match_type, sem_rank, kw_rank in merged[:limit]:
             result = SearchResult(
                 file_metadata=file_metadata,
-                semantic_score=semantic_score,
-                keyword_score=keyword_score
+                combined_score=rrf_score,
+                match_type=match_type,
+                semantic_rank=sem_rank,
+                keyword_rank=kw_rank,
             )
-
-            # Apply improved additive scoring algorithm
-            semantic_component = 0.0
-            keyword_component = 0.0
-            
-            # Semantic component: Convert distance to similarity and normalize
-            if result.semantic_score is not None:
-                # Convert distance (lower=better) to similarity (higher=better)
-                # Use exponential decay to emphasize closer matches
-                import math
-                semantic_similarity = math.exp(-result.semantic_score)  # Range: 0-1, closer=higher
-                semantic_component = semantic_similarity * 0.5  # Scale to 0-0.5 range
-                
-            # Keyword component: Direct score
-            if result.keyword_score is not None:
-                keyword_component = result.keyword_score * 0.5  # Scale to 0-0.5 range
-                
-            # Combined score: Sum of components (not weighted average)
-            result.combined_score = semantic_component + keyword_component
-            
-            # Determine match type based on components
-            if semantic_component > 0 and keyword_component > 0:
-                result.match_type = "hybrid"
-            elif keyword_component > 0:
-                result.match_type = "keyword"  
-            elif semantic_component > 0:
-                result.match_type = "semantic"
-            else:
-                result.match_type = "none"
-
-            combined_results.append(result)
-
-        # Sort by combined score (descending)
-        combined_results.sort(key=lambda x: x.combined_score, reverse=True)
-
-        # Limit results
-        final_results = combined_results[:limit]
+            results.append(result)
 
         logger.info(sm("Hybrid search completed",
-                       total_results=len(final_results),
-                       semantic_matches=len(semantic_results),
-                       keyword_matches=len(keyword_results)))
+                       total_results=len(results),
+                       semantic_matches=len(semantic_list),
+                       keyword_matches=len(keyword_list)))
 
-        return final_results
+        return results
 
     async def _semantic_search(self, query: str, limit: int, threshold: float, directory: str | None = None) -> list[tuple]:
         """Perform semantic search using embeddings."""
@@ -290,12 +233,14 @@ class HybridSearcher:
 
             # Convert to SearchResult objects, excluding the original file
             search_results = []
-            for file_metadata, distance in results:
+            for rank, (file_metadata, distance) in enumerate(results):
                 if hasattr(file_metadata, "id") and file_metadata.id != file_id:
+                    # For similar-to-file search, use simple rank-based scoring
                     result = SearchResult(
                         file_metadata=file_metadata,
-                        semantic_score=distance,
-                        match_type="semantic"
+                        combined_score=1.0 / (60 + rank),  # RRF-style score
+                        match_type="semantic",
+                        semantic_rank=rank,
                     )
                     search_results.append(result)
 
@@ -317,10 +262,10 @@ class HybridSearcher:
 
     async def get_search_suggestions(self, query: str, limit: int = 5) -> list[str]:
         """
-        Get search suggestions based on existing keywords and file titles.
+        Get search suggestions using FTS5 prefix matching.
 
         Args:
-            query: Partial query
+            query: Partial query (prefix)
             limit: Maximum number of suggestions
 
         Returns:
@@ -328,38 +273,18 @@ class HybridSearcher:
         """
         logger.debug(sm("Getting search suggestions", query=query))
 
+        if not query or not query.strip():
+            return []
+
         try:
-            # Get all files to extract keywords and titles
-            files = await self.db.get_files(limit=1000)  # Reasonable limit
-
-            suggestions = set()
-            query_lower = query.lower()
-
-            for file_metadata in files:
-                # Add matching keywords
-                if file_metadata.keywords:
-                    for keyword in file_metadata.keywords:
-                        if keyword.lower().startswith(query_lower):
-                            suggestions.add(keyword)
-
-                # Add matching title words
-                if file_metadata.title:
-                    for word in file_metadata.title.split():
-                        if word.lower().startswith(query_lower) and len(word) > 2:
-                            suggestions.add(word)
-
-                # Stop if we have enough suggestions
-                if len(suggestions) >= limit * 2:
-                    break
-
-            # Sort suggestions by relevance (simple alphabetical for now)
-            sorted_suggestions = sorted(suggestions)[:limit]
+            # Use FTS5 prefix search for efficient autocomplete
+            suggestions = await self.db.get_fts5_suggestions(query.strip(), limit)
 
             logger.debug(sm("Generated search suggestions",
                             query=query,
-                            suggestions=len(sorted_suggestions)))
+                            suggestions=len(suggestions)))
 
-            return sorted_suggestions
+            return suggestions
 
         except Exception as e:
             logger.exception(sm("Failed to get search suggestions",

--- a/packages/cosma-backend/tests/integration/test_database.py
+++ b/packages/cosma-backend/tests/integration/test_database.py
@@ -169,24 +169,15 @@ class TestDatabaseOperations:
 
     async def test_keyword_search(self, temp_db: Database, sample_file_data):
         """Test keyword search functionality."""
-        # Insert file with specific content - FTS indexes title, summary, and keywords
+        # Insert file with searchable content
+        # FTS indexes: file_path, title, summary, keywords (via triggers)
         file_obj = File(**sample_file_data)
-        file_obj.title = "Artificial Intelligence Research"
-        file_obj.summary = "This is a document about artificial intelligence and machine learning"
+        file_obj.title = "Artificial Intelligence and Machine Learning Guide"
+        file_obj.summary = "A document about artificial intelligence and machine learning concepts"
         file_obj.keywords = ["AI", "ML", "technology", "research"]
         await temp_db.upsert_file(file_obj)
 
-        # Manually insert into FTS table since the trigger relies on file_keywords table
-        # and the FTS table only indexes: file_path, title, summary, keywords
-        async with temp_db.acquire() as conn:
-            await conn.execute(
-                """INSERT INTO files_fts (rowid, file_path, title, summary, keywords)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (file_obj.id, file_obj.file_path, file_obj.title,
-                 file_obj.summary or "", " ".join(file_obj.keywords or []))
-            )
-
-        # Search for "artificial intelligence" - this should match title and summary
+        # Search for terms in title/summary (FTS triggers auto-populate)
         results = await temp_db.keyword_search("artificial intelligence", limit=10)
 
         # Should find our file
@@ -195,7 +186,7 @@ class TestDatabaseOperations:
         found_file, relevance_score = results[0]
         assert isinstance(found_file, File)
         assert isinstance(relevance_score, (int, float))
-        assert "artificial" in found_file.title.lower() or "intelligence" in found_file.summary.lower()
+        assert found_file.id == file_obj.id
 
     async def test_add_watched_directory(self, temp_db: Database):
         """Test adding a watched directory."""

--- a/packages/cosma-backend/tests/integration/test_search.py
+++ b/packages/cosma-backend/tests/integration/test_search.py
@@ -1,0 +1,303 @@
+"""Integration tests for search functionality."""
+
+import pytest
+import pytest_asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+import numpy as np
+
+from cosma_backend.db.database import Database
+from cosma_backend.models.file import File
+from cosma_backend.models.status import ProcessingStatus
+from cosma_backend.searcher.searcher import HybridSearcher, SearchResult
+
+
+@pytest_asyncio.fixture
+async def populated_db(temp_db: Database):
+    """Create a database with sample files for search testing."""
+    files_data = [
+        {
+            "file_path": "/docs/python_tutorial.md",
+            "filename": "python_tutorial.md",
+            "title": "Python Programming Tutorial",
+            "summary": "A comprehensive guide to learning Python programming language",
+            "content": "Python is a versatile programming language used for web development and data science.",
+            "keywords": ["python", "programming", "tutorial"],
+        },
+        {
+            "file_path": "/docs/javascript_guide.md",
+            "filename": "javascript_guide.md",
+            "title": "JavaScript Developer Guide",
+            "summary": "Modern JavaScript development practices and patterns",
+            "content": "JavaScript powers the modern web with frameworks like React and Vue.",
+            "keywords": ["javascript", "web", "development"],
+        },
+        {
+            "file_path": "/docs/machine_learning.md",
+            "filename": "machine_learning.md",
+            "title": "Machine Learning Fundamentals",
+            "summary": "Introduction to machine learning concepts and algorithms",
+            "content": "Machine learning uses Python libraries like scikit-learn and TensorFlow.",
+            "keywords": ["machine learning", "python", "ai"],
+        },
+        {
+            "file_path": "/notes/meeting_notes.txt",
+            "filename": "meeting_notes.txt",
+            "title": "Team Meeting Notes",
+            "summary": "Notes from the weekly team meeting",
+            "content": "Discussed project timeline and deliverables for Q1.",
+            "keywords": ["meeting", "notes", "team"],
+        },
+        {
+            "file_path": "/code/test_utils.py",
+            "filename": "test_utils.py",
+            "title": "Test Utilities",
+            "summary": "Utility functions for testing",
+            "content": "Helper functions for unit testing Python applications.",
+            "keywords": ["testing", "python", "utilities"],
+        },
+    ]
+
+    now = datetime.now(timezone.utc)
+
+    for data in files_data:
+        file = File(
+            path=Path(data["file_path"]),
+            file_path=data["file_path"],
+            filename=data["filename"],
+            extension=Path(data["filename"]).suffix,
+            file_size=1024,
+            created=now,
+            modified=now,
+            accessed=now,
+            content_type="text/plain",
+            content=data["content"],
+            content_hash=f"hash_{data['filename']}",
+            summary=data["summary"],
+            title=data["title"],
+            keywords=data["keywords"],
+            status=ProcessingStatus.COMPLETE,
+        )
+        await temp_db.upsert_file(file)
+
+    return temp_db
+
+
+@pytest.mark.integration
+class TestKeywordSearch:
+    """Integration tests for keyword search."""
+
+    @pytest.mark.asyncio
+    async def test_basic_keyword_search(self, populated_db: Database):
+        """Test basic keyword search returns results."""
+        results = await populated_db.keyword_search("python", limit=10)
+
+        assert len(results) > 0
+        # All results should have a score
+        for file, score in results:
+            assert score > 0
+            assert file.file_path is not None
+
+    @pytest.mark.asyncio
+    async def test_keyword_search_with_special_chars(self, populated_db: Database):
+        """Test keyword search handles special characters safely."""
+        # These should not crash even with FTS5 special characters
+        special_queries = [
+            'test"query',
+            "test*",
+            "test:value",
+            "(test)",
+            "test AND query",  # Should be treated as literal without operators
+        ]
+
+        for query in special_queries:
+            # Should not raise an exception
+            results = await populated_db.keyword_search(query, limit=10)
+            # Results may be empty, but should not crash
+            assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_keyword_search_empty_query(self, populated_db: Database):
+        """Test keyword search with empty query returns empty results."""
+        results = await populated_db.keyword_search("", limit=10)
+        assert results == []
+
+        results = await populated_db.keyword_search("   ", limit=10)
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_keyword_search_directory_filter(self, populated_db: Database):
+        """Test keyword search with directory filter."""
+        # Search only in /docs directory
+        results = await populated_db.keyword_search("python", limit=10, directory="/docs")
+
+        for file, _score in results:
+            assert file.file_path.startswith("/docs")
+
+    @pytest.mark.asyncio
+    async def test_keyword_search_with_operators(self, populated_db: Database):
+        """Test keyword search with boolean operators enabled."""
+        # With operators enabled, AND should be a boolean operator
+        results = await populated_db.keyword_search(
+            "python AND learning",
+            limit=10,
+            allow_operators=True
+        )
+
+        # Should find the machine learning file which has both terms
+        assert len(results) >= 0  # May or may not find results depending on content
+
+
+@pytest.mark.integration
+class TestHybridSearch:
+    """Integration tests for hybrid search with RRF."""
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_returns_results(self, populated_db: Database, mock_embedder):
+        """Test that hybrid search returns results with RRF scores."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        results = await searcher.search("python programming", limit=5)
+
+        assert len(results) > 0
+        for result in results:
+            assert isinstance(result, SearchResult)
+            assert result.combined_score > 0
+            assert result.match_type in ["semantic", "keyword", "hybrid"]
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_rrf_scores_are_small(self, populated_db: Database, mock_embedder):
+        """Test that RRF scores are in expected range (small values)."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        results = await searcher.search("python", limit=10)
+
+        for result in results:
+            # RRF scores are typically small (1/k range)
+            # With k=60, max single-list score is ~0.0167
+            # With both lists, max is ~0.0333
+            assert result.combined_score < 0.1
+            assert result.combined_score > 0
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_preserves_match_type(self, populated_db: Database, mock_embedder):
+        """Test that match_type is correctly set based on result sources."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        results = await searcher.search("python", limit=10)
+
+        # At least some results should exist
+        assert len(results) > 0
+
+        # Match types should be valid
+        valid_types = {"semantic", "keyword", "hybrid"}
+        for result in results:
+            assert result.match_type in valid_types
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_with_directory_filter(self, populated_db: Database, mock_embedder):
+        """Test hybrid search with directory filtering."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        results = await searcher.search("python", limit=10, directory="/docs")
+
+        for result in results:
+            assert result.file_metadata.file_path.startswith("/docs")
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_special_characters(self, populated_db: Database, mock_embedder):
+        """Test hybrid search handles special characters safely."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        special_queries = [
+            'test"quote',
+            "test*wildcard",
+            "test:colon",
+            "(parentheses)",
+        ]
+
+        for query in special_queries:
+            # Should not raise an exception
+            results = await searcher.search(query, limit=5)
+            assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_empty_query(self, populated_db: Database, mock_embedder):
+        """Test hybrid search with empty query."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        # Empty query should still work (semantic search may return results)
+        results = await searcher.search("", limit=5)
+        assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_hybrid_search_ranks_preserved(self, populated_db: Database, mock_embedder):
+        """Test that semantic and keyword ranks are preserved in results."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        results = await searcher.search("python", limit=10)
+
+        for result in results:
+            # At least one rank should be set
+            has_semantic = result.semantic_rank is not None
+            has_keyword = result.keyword_rank is not None
+            assert has_semantic or has_keyword
+
+            # Hybrid results should have both
+            if result.match_type == "hybrid":
+                assert has_semantic and has_keyword
+
+
+@pytest.mark.integration
+class TestSearchSuggestions:
+    """Integration tests for search suggestions."""
+
+    @pytest.mark.asyncio
+    async def test_get_fts5_suggestions(self, populated_db: Database):
+        """Test FTS5-based suggestions."""
+        suggestions = await populated_db.get_fts5_suggestions("pyth", limit=5)
+
+        # Should find suggestions starting with "pyth"
+        assert isinstance(suggestions, list)
+
+    @pytest.mark.asyncio
+    async def test_get_fts5_suggestions_empty_prefix(self, populated_db: Database):
+        """Test suggestions with empty prefix."""
+        suggestions = await populated_db.get_fts5_suggestions("", limit=5)
+        assert suggestions == []
+
+    @pytest.mark.asyncio
+    async def test_search_suggestions_via_searcher(self, populated_db: Database, mock_embedder):
+        """Test search suggestions through the searcher."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        suggestions = await searcher.get_search_suggestions("pyth", limit=5)
+
+        assert isinstance(suggestions, list)
+
+
+@pytest.mark.integration
+class TestSearchResultSerialization:
+    """Integration tests for SearchResult serialization."""
+
+    @pytest.mark.asyncio
+    async def test_search_result_to_json(self, populated_db: Database, mock_embedder):
+        """Test SearchResult.to_json() includes all fields."""
+        searcher = HybridSearcher(db=populated_db, embedder=mock_embedder)
+
+        results = await searcher.search("python", limit=1)
+
+        if results:
+            result = results[0]
+            json_data = result.to_json()
+
+            assert "file_path" in json_data
+            assert "filename" in json_data
+            assert "combined_score" in json_data
+            assert "match_type" in json_data
+            assert "semantic_rank" in json_data
+            assert "keyword_rank" in json_data
+
+            # Verify types
+            assert isinstance(json_data["combined_score"], float)
+            assert isinstance(json_data["match_type"], str)

--- a/packages/cosma-backend/tests/unit/test_searcher.py
+++ b/packages/cosma-backend/tests/unit/test_searcher.py
@@ -1,0 +1,245 @@
+"""Unit tests for search functionality including FTS5 query parsing and RRF."""
+
+import pytest
+
+from cosma_backend.searcher.fts5_query import (
+    escape_fts5_token,
+    parse_fts5_query,
+    build_prefix_query,
+)
+from cosma_backend.searcher.rrf import compute_rrf_scores, merge_with_rrf
+
+
+@pytest.mark.unit
+class TestFTS5QueryParser:
+    """Test cases for FTS5 query parsing and escaping."""
+
+    def test_escape_empty_token(self):
+        """Test escaping an empty token."""
+        assert escape_fts5_token("") == ""
+        assert escape_fts5_token(None) == ""
+
+    def test_escape_simple_token(self):
+        """Test escaping a simple token without special characters."""
+        assert escape_fts5_token("hello") == '"hello"'
+        assert escape_fts5_token("world") == '"world"'
+
+    def test_escape_token_with_quotes(self):
+        """Test escaping a token containing double quotes."""
+        assert escape_fts5_token('test"quote') == '"test""quote"'
+        assert escape_fts5_token('"quoted"') == '"""quoted"""'
+
+    def test_escape_token_with_special_chars(self):
+        """Test escaping tokens with FTS5 special characters."""
+        # These are wrapped in quotes which makes them literal
+        assert escape_fts5_token("test*") == '"test*"'
+        assert escape_fts5_token("test:value") == '"test:value"'
+        assert escape_fts5_token("(parens)") == '"(parens)"'
+
+    def test_parse_empty_query(self):
+        """Test parsing an empty query."""
+        assert parse_fts5_query("") == ""
+        assert parse_fts5_query("   ") == ""
+        assert parse_fts5_query(None) == ""
+
+    def test_parse_single_term(self):
+        """Test parsing a single search term."""
+        assert parse_fts5_query("hello") == '"hello"'
+        assert parse_fts5_query("  hello  ") == '"hello"'
+
+    def test_parse_multiple_terms(self):
+        """Test parsing multiple search terms."""
+        assert parse_fts5_query("hello world") == '"hello" "world"'
+        assert parse_fts5_query("one two three") == '"one" "two" "three"'
+
+    def test_parse_with_special_characters(self):
+        """Test parsing queries with special characters."""
+        # Special chars should be escaped by wrapping in quotes
+        assert parse_fts5_query('test"query') == '"test""query"'
+        assert parse_fts5_query("test*") == '"test*"'
+        assert parse_fts5_query("test:value") == '"test:value"'
+
+    def test_parse_with_operators_disabled(self):
+        """Test that operators are escaped when allow_operators=False."""
+        # AND, OR, NOT should be treated as literal terms
+        assert parse_fts5_query("test AND query") == '"test" "AND" "query"'
+        assert parse_fts5_query("foo OR bar") == '"foo" "OR" "bar"'
+
+    def test_parse_with_operators_enabled(self):
+        """Test that operators are preserved when allow_operators=True."""
+        assert parse_fts5_query("test AND query", allow_operators=True) == '"test" AND "query"'
+        assert parse_fts5_query("foo OR bar", allow_operators=True) == '"foo" OR "bar"'
+        assert parse_fts5_query("NOT excluded", allow_operators=True) == 'NOT "excluded"'
+
+    def test_parse_mixed_operators_and_terms(self):
+        """Test parsing mixed operators and terms."""
+        result = parse_fts5_query("hello AND world OR test", allow_operators=True)
+        assert result == '"hello" AND "world" OR "test"'
+
+    def test_build_prefix_query_empty(self):
+        """Test building prefix query with empty input."""
+        assert build_prefix_query("") == ""
+        assert build_prefix_query("   ") == ""
+
+    def test_build_prefix_query_simple(self):
+        """Test building a simple prefix query."""
+        assert build_prefix_query("test") == '"test"*'
+        assert build_prefix_query("hello") == '"hello"*'
+
+    def test_build_prefix_query_strips_special_chars(self):
+        """Test that prefix query strips special characters."""
+        assert build_prefix_query("test*") == '"test"*'
+        assert build_prefix_query('test"') == '"test"*'
+        assert build_prefix_query("test:") == '"test"*'
+
+
+@pytest.mark.unit
+class TestRRF:
+    """Test cases for Reciprocal Rank Fusion."""
+
+    def test_compute_rrf_empty_lists(self):
+        """Test RRF with empty lists."""
+        scores = compute_rrf_scores([])
+        assert scores == {}
+
+        scores = compute_rrf_scores([[]])
+        assert scores == {}
+
+    def test_compute_rrf_single_list(self):
+        """Test RRF with a single ranked list."""
+        ranked_list = [("a", "data_a"), ("b", "data_b"), ("c", "data_c")]
+        scores = compute_rrf_scores([ranked_list], k=60)
+
+        # First item: 1/(60+0) = 1/60
+        # Second item: 1/(60+1) = 1/61
+        # Third item: 1/(60+2) = 1/62
+        assert abs(scores["a"] - 1/60) < 0.0001
+        assert abs(scores["b"] - 1/61) < 0.0001
+        assert abs(scores["c"] - 1/62) < 0.0001
+
+    def test_compute_rrf_multiple_lists(self):
+        """Test RRF with multiple ranked lists."""
+        list1 = [("a", "data"), ("b", "data"), ("c", "data")]
+        list2 = [("b", "data"), ("a", "data"), ("d", "data")]
+
+        scores = compute_rrf_scores([list1, list2], k=60)
+
+        # "a": 1/60 + 1/61 (rank 0 in list1, rank 1 in list2)
+        # "b": 1/61 + 1/60 (rank 1 in list1, rank 0 in list2)
+        # "c": 1/62 (only in list1 at rank 2)
+        # "d": 1/62 (only in list2 at rank 2)
+
+        expected_a = 1/60 + 1/61
+        expected_b = 1/61 + 1/60
+        expected_c = 1/62
+        expected_d = 1/62
+
+        assert abs(scores["a"] - expected_a) < 0.0001
+        assert abs(scores["b"] - expected_b) < 0.0001
+        assert abs(scores["c"] - expected_c) < 0.0001
+        assert abs(scores["d"] - expected_d) < 0.0001
+
+        # a and b should have the same score (symmetric)
+        assert abs(scores["a"] - scores["b"]) < 0.0001
+
+    def test_compute_rrf_items_in_both_lists_rank_higher(self):
+        """Test that items appearing in both lists get higher RRF scores."""
+        list1 = [("shared", "data"), ("only_in_1", "data")]
+        list2 = [("shared", "data"), ("only_in_2", "data")]
+
+        scores = compute_rrf_scores([list1, list2], k=60)
+
+        # shared appears in both lists at rank 0: 1/60 + 1/60 = 2/60
+        # others appear only in one list: 1/61 each
+        assert scores["shared"] > scores["only_in_1"]
+        assert scores["shared"] > scores["only_in_2"]
+
+    def test_merge_with_rrf_empty_inputs(self):
+        """Test merge_with_rrf with empty inputs."""
+        result = merge_with_rrf([], [])
+        assert result == []
+
+    def test_merge_with_rrf_semantic_only(self):
+        """Test merge_with_rrf with only semantic results."""
+        semantic = [(1, "file_1", 0.5), (2, "file_2", 0.7)]
+        keyword = []
+
+        result = merge_with_rrf(semantic, keyword, k=60)
+
+        assert len(result) == 2
+        # Check first result
+        assert result[0][0] == 1  # id
+        assert result[0][1] == "file_1"  # data
+        assert result[0][3] == "semantic"  # match_type
+        assert result[0][4] == 0  # semantic_rank
+        assert result[0][5] is None  # keyword_rank
+
+    def test_merge_with_rrf_keyword_only(self):
+        """Test merge_with_rrf with only keyword results."""
+        semantic = []
+        keyword = [(1, "file_1", 0.9), (2, "file_2", 0.8)]
+
+        result = merge_with_rrf(semantic, keyword, k=60)
+
+        assert len(result) == 2
+        assert result[0][3] == "keyword"  # match_type
+        assert result[0][4] is None  # semantic_rank
+        assert result[0][5] == 0  # keyword_rank
+
+    def test_merge_with_rrf_hybrid_results(self):
+        """Test merge_with_rrf with overlapping results."""
+        semantic = [(1, "file_1", 0.3), (2, "file_2", 0.5), (3, "file_3", 0.7)]
+        keyword = [(2, "file_2", 0.9), (4, "file_4", 0.8), (1, "file_1", 0.7)]
+
+        result = merge_with_rrf(semantic, keyword, k=60)
+
+        # Create lookup by id for easier assertions
+        result_by_id = {r[0]: r for r in result}
+
+        # file_1 and file_2 appear in both - should be hybrid
+        assert result_by_id[1][3] == "hybrid"
+        assert result_by_id[2][3] == "hybrid"
+
+        # file_3 only in semantic
+        assert result_by_id[3][3] == "semantic"
+
+        # file_4 only in keyword
+        assert result_by_id[4][3] == "keyword"
+
+        # Check ranks are preserved
+        assert result_by_id[1][4] == 0  # semantic_rank for file_1
+        assert result_by_id[1][5] == 2  # keyword_rank for file_1
+        assert result_by_id[2][4] == 1  # semantic_rank for file_2
+        assert result_by_id[2][5] == 0  # keyword_rank for file_2
+
+    def test_merge_with_rrf_sorting(self):
+        """Test that merge_with_rrf returns results sorted by RRF score."""
+        # file_2 appears first in keyword, second in semantic
+        # file_1 appears first in semantic, third in keyword
+        # file_2 should rank higher due to better average position
+        semantic = [(1, "file_1", 0.3), (2, "file_2", 0.5)]
+        keyword = [(2, "file_2", 0.9), (3, "file_3", 0.8), (1, "file_1", 0.7)]
+
+        result = merge_with_rrf(semantic, keyword, k=60)
+
+        # file_2: 1/61 + 1/60 = top scorer (rank 1 in semantic, rank 0 in keyword)
+        # file_1: 1/60 + 1/62 = second (rank 0 in semantic, rank 2 in keyword)
+        # file_3: 1/61 = third (only in keyword at rank 1)
+
+        assert result[0][0] == 2  # file_2 should be first
+        assert result[1][0] == 1  # file_1 should be second
+        assert result[2][0] == 3  # file_3 should be third
+
+    def test_merge_with_rrf_k_parameter(self):
+        """Test that different k values affect scores but not relative ranking."""
+        semantic = [(1, "file_1", 0.3), (2, "file_2", 0.5)]
+        keyword = [(2, "file_2", 0.9), (1, "file_1", 0.8)]
+
+        result_k60 = merge_with_rrf(semantic, keyword, k=60)
+        result_k10 = merge_with_rrf(semantic, keyword, k=10)
+
+        # Relative ordering should be the same
+        assert [r[0] for r in result_k60] == [r[0] for r in result_k10]
+
+        # But scores should be different (higher with lower k)
+        assert result_k10[0][2] > result_k60[0][2]

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "cosma"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click-help-colors" },
@@ -454,7 +454,7 @@ dev = [
 
 [[package]]
 name = "cosma-backend"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/cosma-backend" }
 dependencies = [
     { name = "asqlite" },
@@ -537,7 +537,7 @@ requires-dist = [{ name = "niquests", specifier = ">=3.15.2" }]
 
 [[package]]
 name = "cosma-tui"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/cosma-tui" }
 dependencies = [
     { name = "cosma-client" },


### PR DESCRIPTION
## Summary
- Replace flawed additive scoring with Reciprocal Rank Fusion (RRF) for combining semantic and keyword search results
- Add FTS5 query parsing to properly escape special characters and prevent query injection
- Add efficient FTS5-based prefix search for autocomplete suggestions
- Fix broken keyword search test that used incorrect FTS table columns

Closes #5

## Test plan
- [x] Run unit tests: `uv run --group test pytest tests/unit/test_searcher.py -v --no-cov` (24 tests pass)
- [x] Run integration tests: `uv run --group test pytest tests/integration/test_search.py -v --no-cov` (16 tests pass)
- [x] Verify special characters in queries don't crash FTS5
- [ ] Manual API test with `curl -X POST http://localhost:60534/api/search/ -H "Content-Type: application/json" -d '{"query": "test"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)