### PR TITLE
Add file filter system with mode-specific pattern storage

### DIFF
--- a/packages/cosma-backend/pyproject.toml
+++ b/packages/cosma-backend/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.12"
 dependencies = [
     "asqlite>=2.0.0",
     "litellm>=1.77.5",
-    "markitdown[docx,pdf,pptx]>=0.1.3",
+    "markitdown[docx,pdf,pptx]>=0.1.4",
     "ollama>=0.6.0",
     "platformdirs>=4.5.0",
     "quart>=0.20.0",

--- a/packages/cosma-backend/src/cosma_backend/api/__init__.py
+++ b/packages/cosma-backend/src/cosma_backend/api/__init__.py
@@ -13,6 +13,7 @@ from .search import search_bp
 from .watch import watch_bp
 from .updates import updates_bp
 from .status import status_bp
+from .filters import filters_bp
 
 # Create the main API blueprint
 api_blueprint = Blueprint('api', __name__)
@@ -24,6 +25,7 @@ api_blueprint.register_blueprint(search_bp, url_prefix='/search')
 api_blueprint.register_blueprint(watch_bp, url_prefix='/watch')
 api_blueprint.register_blueprint(updates_bp, url_prefix='/updates')
 api_blueprint.register_blueprint(status_bp, url_prefix='/status')
+api_blueprint.register_blueprint(filters_bp, url_prefix='/filters')
 
 
 __all__ = ['api_blueprint']

--- a/packages/cosma-backend/src/cosma_backend/api/filters.py
+++ b/packages/cosma-backend/src/cosma_backend/api/filters.py
@@ -1,0 +1,580 @@
+"""
+Filters API Blueprint
+
+Handles endpoints related to file filtering configuration.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from quart import Blueprint, current_app
+from quart_schema import validate_request, validate_response
+
+from cosma_backend.filter import FilterConfig, FilterMode
+
+if TYPE_CHECKING:
+    from cosma_backend.app import App
+    current_app: App
+
+filters_bp = Blueprint('filters', __name__)
+
+
+# ============================================================================
+# Request/Response Models
+# ============================================================================
+
+@dataclass
+class FilterConfigResponse:
+    """Response containing filter configuration."""
+    version: int
+    mode: str  # "blacklist" or "whitelist"
+    # Legacy fields (deprecated but kept for compatibility)
+    exclude: list[str]
+    include: list[str]
+    # Mode-specific pattern storage (NEW)
+    blacklist_exclude: list[str]
+    blacklist_include: list[str]
+    whitelist_include: list[str]
+    whitelist_exclude: list[str]
+    config_path: str
+
+
+@dataclass
+class UpdateFilterConfigRequest:
+    """Request to update filter configuration."""
+    mode: Optional[str] = None  # "blacklist" or "whitelist"
+    # Legacy fields (deprecated but kept for compatibility)
+    exclude: Optional[list[str]] = None
+    include: Optional[list[str]] = None
+    # Mode-specific pattern storage (NEW)
+    blacklist_exclude: Optional[list[str]] = None
+    blacklist_include: Optional[list[str]] = None
+    whitelist_include: Optional[list[str]] = None
+    whitelist_exclude: Optional[list[str]] = None
+    # Control whether to apply changes immediately
+    apply_immediately: bool = True  # If False, just update config without cleaning DB
+
+
+@dataclass
+class UpdateFilterConfigResponse:
+    """Response after updating filter configuration."""
+    success: bool
+    message: str
+    config: FilterConfigResponse
+    removed_count: int  # Number of files removed from index
+
+
+@dataclass
+class TestPatternRequest:
+    """Request to test pattern matching."""
+    patterns: list[str]
+    file_paths: list[str]
+    mode: str = "blacklist"  # "blacklist" or "whitelist"
+
+
+@dataclass
+class PatternTestResult:
+    """Result of testing a single file path."""
+    file_path: str
+    included: bool
+    matched_pattern: Optional[str]
+
+
+@dataclass
+class TestPatternResponse:
+    """Response for pattern testing."""
+    results: list[PatternTestResult]
+
+
+@dataclass
+class AddPatternRequest:
+    """Request to add a pattern."""
+    pattern: str
+    pattern_type: str = "exclude"  # "exclude" or "include"
+
+
+@dataclass
+class AddPatternResponse:
+    """Response after adding a pattern."""
+    success: bool
+    message: str
+    removed_count: int  # Files removed if exclude pattern added
+
+
+@dataclass
+class RemovePatternRequest:
+    """Request to remove a pattern."""
+    pattern: str
+    pattern_type: str = "exclude"  # "exclude" or "include"
+
+
+@dataclass
+class RemovePatternResponse:
+    """Response after removing a pattern."""
+    success: bool
+    message: str
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+@filters_bp.get("/config")
+@validate_response(FilterConfigResponse, 200)
+async def get_filter_config() -> tuple[FilterConfigResponse, int]:
+    """
+    Get the current global filter configuration.
+
+    GET /api/filters/config
+
+    Returns:
+        200: Current filter configuration with mode-specific patterns
+    """
+    config = current_app.filter_manager.global_config
+
+    return FilterConfigResponse(
+        version=config.version,
+        mode=config.mode.value,
+        # Legacy fields for backward compatibility
+        exclude=config.exclude,
+        include=config.include,
+        # Mode-specific patterns
+        blacklist_exclude=config.blacklist_exclude,
+        blacklist_include=config.blacklist_include,
+        whitelist_include=config.whitelist_include,
+        whitelist_exclude=config.whitelist_exclude,
+        config_path=str(config.config_path) if config.config_path else "",
+    ), 200
+
+
+@filters_bp.put("/config")
+@validate_request(UpdateFilterConfigRequest)
+@validate_response(UpdateFilterConfigResponse, 200)
+async def update_filter_config(data: UpdateFilterConfigRequest) -> tuple[UpdateFilterConfigResponse, int]:
+    """
+    Update the global filter configuration.
+
+    PUT /api/filters/config
+
+    This will:
+    1. Update the configuration
+    2. Save to the config file
+    3. Optionally remove files from index (if apply_immediately=True)
+
+    NEW: Supports mode-specific pattern storage to prevent data loss
+    when switching modes. Set apply_immediately=False to update config
+    without triggering database cleanup (useful for frontend local editing).
+
+    Returns:
+        200: Configuration updated successfully
+    """
+    # Parse mode if provided
+    mode = None
+    if data.mode is not None:
+        try:
+            mode = FilterMode(data.mode)
+        except ValueError:
+            return UpdateFilterConfigResponse(
+                success=False,
+                message=f"Invalid mode: {data.mode}. Must be 'blacklist' or 'whitelist'",
+                config=FilterConfigResponse(
+                    version=2,
+                    mode="blacklist",
+                    exclude=[],
+                    include=[],
+                    blacklist_exclude=[],
+                    blacklist_include=[],
+                    whitelist_include=[],
+                    whitelist_exclude=[],
+                    config_path="",
+                ),
+                removed_count=0,
+            ), 400
+
+    # Update configuration
+    new_config = current_app.filter_manager.update_global_config(
+        mode=mode,
+        exclude=data.exclude,
+        include=data.include,
+        blacklist_exclude=data.blacklist_exclude,
+        blacklist_include=data.blacklist_include,
+        whitelist_include=data.whitelist_include,
+        whitelist_exclude=data.whitelist_exclude,
+    )
+
+    # Clean up excluded files from database only if apply_immediately=True
+    removed_count = 0
+    if data.apply_immediately:
+        removed_count = await cleanup_excluded_files()
+
+    return UpdateFilterConfigResponse(
+        success=True,
+        message="Filter configuration updated successfully",
+        config=FilterConfigResponse(
+            version=new_config.version,
+            mode=new_config.mode.value,
+            exclude=new_config.exclude,
+            include=new_config.include,
+            blacklist_exclude=new_config.blacklist_exclude,
+            blacklist_include=new_config.blacklist_include,
+            whitelist_include=new_config.whitelist_include,
+            whitelist_exclude=new_config.whitelist_exclude,
+            config_path=str(new_config.config_path) if new_config.config_path else "",
+        ),
+        removed_count=removed_count,
+    ), 200
+
+
+@filters_bp.post("/pattern")
+@validate_request(AddPatternRequest)
+@validate_response(AddPatternResponse, 200)
+async def add_pattern(data: AddPatternRequest) -> tuple[AddPatternResponse, int]:
+    """
+    Add a single pattern to the filter configuration.
+
+    POST /api/filters/pattern
+
+    Returns:
+        200: Pattern added successfully
+    """
+    config = current_app.filter_manager.global_config
+
+    if data.pattern_type == "exclude":
+        if data.pattern in config.exclude:
+            return AddPatternResponse(
+                success=False,
+                message=f"Pattern '{data.pattern}' already exists in exclude list",
+                removed_count=0,
+            ), 400
+
+        new_exclude = config.exclude + [data.pattern]
+        current_app.filter_manager.update_global_config(exclude=new_exclude)
+
+        # Clean up files matching new exclude pattern
+        removed_count = await cleanup_excluded_files()
+
+        return AddPatternResponse(
+            success=True,
+            message=f"Added exclude pattern: {data.pattern}",
+            removed_count=removed_count,
+        ), 200
+
+    elif data.pattern_type == "include":
+        if data.pattern in config.include:
+            return AddPatternResponse(
+                success=False,
+                message=f"Pattern '{data.pattern}' already exists in include list",
+                removed_count=0,
+            ), 400
+
+        new_include = config.include + [data.pattern]
+        current_app.filter_manager.update_global_config(include=new_include)
+
+        return AddPatternResponse(
+            success=True,
+            message=f"Added include pattern: {data.pattern}",
+            removed_count=0,
+        ), 200
+
+    else:
+        return AddPatternResponse(
+            success=False,
+            message=f"Invalid pattern_type: {data.pattern_type}. Must be 'exclude' or 'include'",
+            removed_count=0,
+        ), 400
+
+
+@filters_bp.delete("/pattern")
+@validate_request(RemovePatternRequest)
+@validate_response(RemovePatternResponse, 200)
+async def remove_pattern(data: RemovePatternRequest) -> tuple[RemovePatternResponse, int]:
+    """
+    Remove a pattern from the filter configuration.
+
+    DELETE /api/filters/pattern
+
+    Returns:
+        200: Pattern removed successfully
+    """
+    config = current_app.filter_manager.global_config
+
+    if data.pattern_type == "exclude":
+        if data.pattern not in config.exclude:
+            return RemovePatternResponse(
+                success=False,
+                message=f"Pattern '{data.pattern}' not found in exclude list",
+            ), 404
+
+        new_exclude = [p for p in config.exclude if p != data.pattern]
+        current_app.filter_manager.update_global_config(exclude=new_exclude)
+
+        return RemovePatternResponse(
+            success=True,
+            message=f"Removed exclude pattern: {data.pattern}",
+        ), 200
+
+    elif data.pattern_type == "include":
+        if data.pattern not in config.include:
+            return RemovePatternResponse(
+                success=False,
+                message=f"Pattern '{data.pattern}' not found in include list",
+            ), 404
+
+        new_include = [p for p in config.include if p != data.pattern]
+        current_app.filter_manager.update_global_config(include=new_include)
+
+        return RemovePatternResponse(
+            success=True,
+            message=f"Removed include pattern: {data.pattern}",
+        ), 200
+
+    else:
+        return RemovePatternResponse(
+            success=False,
+            message=f"Invalid pattern_type: {data.pattern_type}. Must be 'exclude' or 'include'",
+        ), 400
+
+
+@filters_bp.post("/test")
+@validate_request(TestPatternRequest)
+@validate_response(TestPatternResponse, 200)
+async def test_patterns(data: TestPatternRequest) -> tuple[TestPatternResponse, int]:
+    """
+    Test pattern matching against a list of file paths.
+
+    POST /api/filters/test
+
+    This is useful for previewing what files would be filtered
+    before applying the configuration.
+
+    Returns:
+        200: Test results
+    """
+    try:
+        mode = FilterMode(data.mode)
+    except ValueError:
+        mode = FilterMode.BLACKLIST
+
+    # Create temporary config for testing
+    # Split patterns into exclude and include based on ! prefix
+    exclude_patterns = [p for p in data.patterns if not p.startswith("!")]
+    include_patterns = [p[1:] for p in data.patterns if p.startswith("!")]
+
+    test_config = FilterConfig(
+        mode=mode,
+        exclude=exclude_patterns,
+        include=include_patterns,
+    )
+
+    results = []
+    for file_path_str in data.file_paths:
+        file_path = Path(file_path_str)
+        # Use parent as base path for testing
+        base_path = file_path.parent
+
+        included = test_config.should_include(file_path, base_path)
+
+        # Find which pattern matched (for debugging)
+        matched_pattern = None
+        filename = file_path.name
+
+        if not included:
+            # Check exclude patterns
+            for pattern in exclude_patterns:
+                temp_config = FilterConfig(mode=mode, exclude=[pattern], include=[])
+                if not temp_config.should_include(file_path, base_path):
+                    matched_pattern = pattern
+                    break
+
+        results.append(PatternTestResult(
+            file_path=file_path_str,
+            included=included,
+            matched_pattern=matched_pattern,
+        ))
+
+    return TestPatternResponse(results=results), 200
+
+
+@filters_bp.get("/defaults")
+@validate_response(FilterConfigResponse, 200)
+async def get_default_config() -> tuple[FilterConfigResponse, int]:
+    """
+    Get the default filter configuration.
+
+    GET /api/filters/defaults
+
+    Returns the default patterns without loading from file.
+
+    Returns:
+        200: Default filter configuration
+    """
+    from cosma_backend.filter.filter_config import (
+        DEFAULT_EXCLUDE_PATTERNS,
+        DEFAULT_INCLUDE_PATTERNS,
+    )
+
+    # Get default whitelist patterns from load_global logic
+    default_whitelist_include = [
+        "*.pdf", "*.docx", "*.doc", "*.pptx", "*.ppt", "*.xlsx", "*.xls",
+        "*.odt", "*.ods", "*.odp", "*.pages", "*.numbers", "*.key",
+        "*.png", "*.jpg", "*.jpeg", "*.tiff", "*.bmp", "*.heic", "*.gif", "*.webp",
+        "*.svg", "*.ico", "*.psd",
+        "*.mp3", "*.wav", "*.aac", "*.m4a", "*.flac", "*.ogg",
+        "*.mp4", "*.avi", "*.mov", "*.mkv", "*.wmv", "*.flv", "*.webm",
+        "*.html", "*.htm", "*.txt", "*.csv", "*.json", "*.xml", "*.md",
+        "*.rtf", "*.log",
+        "*.yaml", "*.yml", "*.toml", "*.ini", "*.cfg",
+        "*.tex", "*.rst", "*.adoc",
+        "*.zip", "*.epub", "*.rar", "*.7z", "*.tar", "*.gz",
+        "*.py", "*.js", "*.java", "*.cpp", "*.c", "*.go", "*.rs", "*.sql", "*.sh",
+        "*.eml", "*.msg",
+        "*.dwg", "*.dxf", "*.skp",
+    ]
+
+    return FilterConfigResponse(
+        version=2,
+        mode="blacklist",
+        exclude=DEFAULT_EXCLUDE_PATTERNS,
+        include=DEFAULT_INCLUDE_PATTERNS,
+        blacklist_exclude=DEFAULT_EXCLUDE_PATTERNS,
+        blacklist_include=DEFAULT_INCLUDE_PATTERNS,
+        whitelist_include=default_whitelist_include,
+        whitelist_exclude=[],
+        config_path="",
+    ), 200
+
+
+@filters_bp.post("/apply")
+@validate_response(UpdateFilterConfigResponse, 200)
+async def apply_filter_changes() -> tuple[UpdateFilterConfigResponse, int]:
+    """
+    Apply current filter configuration to database.
+
+    POST /api/filters/apply
+
+    This triggers cleanup of files that should now be excluded based on
+    the current filter configuration. Use this after updating config with
+    apply_immediately=False.
+
+    Returns:
+        200: Filter changes applied successfully
+    """
+    config = current_app.filter_manager.global_config
+
+    # Clean up excluded files from database
+    removed_count = await cleanup_excluded_files()
+
+    return UpdateFilterConfigResponse(
+        success=True,
+        message=f"Filter changes applied: {removed_count} files removed from index",
+        config=FilterConfigResponse(
+            version=config.version,
+            mode=config.mode.value,
+            exclude=config.exclude,
+            include=config.include,
+            blacklist_exclude=config.blacklist_exclude,
+            blacklist_include=config.blacklist_include,
+            whitelist_include=config.whitelist_include,
+            whitelist_exclude=config.whitelist_exclude,
+            config_path=str(config.config_path) if config.config_path else "",
+        ),
+        removed_count=removed_count,
+    ), 200
+
+
+@filters_bp.post("/reset")
+@validate_response(UpdateFilterConfigResponse, 200)
+async def reset_to_defaults() -> tuple[UpdateFilterConfigResponse, int]:
+    """
+    Reset filter configuration to defaults.
+
+    POST /api/filters/reset
+
+    Returns:
+        200: Configuration reset successfully
+    """
+    from cosma_backend.filter.filter_config import (
+        DEFAULT_EXCLUDE_PATTERNS,
+        DEFAULT_INCLUDE_PATTERNS,
+    )
+
+    new_config = current_app.filter_manager.update_global_config(
+        mode=FilterMode.BLACKLIST,
+        exclude=DEFAULT_EXCLUDE_PATTERNS.copy(),
+        include=DEFAULT_INCLUDE_PATTERNS.copy(),
+    )
+
+    # Clean up excluded files
+    removed_count = await cleanup_excluded_files()
+
+    return UpdateFilterConfigResponse(
+        success=True,
+        message="Filter configuration reset to defaults",
+        config=FilterConfigResponse(
+            version=new_config.version,
+            mode=new_config.mode.value,
+            exclude=new_config.exclude,
+            include=new_config.include,
+            blacklist_exclude=new_config.blacklist_exclude,
+            blacklist_include=new_config.blacklist_include,
+            whitelist_include=new_config.whitelist_include,
+            whitelist_exclude=new_config.whitelist_exclude,
+            config_path=str(new_config.config_path) if new_config.config_path else "",
+        ),
+        removed_count=removed_count,
+    ), 200
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+async def cleanup_excluded_files() -> int:
+    """
+    Remove files from the database that now match exclusion patterns.
+
+    Returns:
+        Number of files removed
+    """
+    from cosma_backend.logging import sm
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    db = current_app.db
+    filter_manager = current_app.filter_manager
+
+    # Get all watched directories
+    watched_dirs = await db.get_watched_directories(active_only=True)
+
+    if not watched_dirs:
+        return 0
+
+    removed_count = 0
+
+    # For each watched directory, check files against filter
+    for watched_dir in watched_dirs:
+        base_path = watched_dir.path
+        config = filter_manager.get_config_for_directory(base_path)
+
+        # Get all files under this directory from database
+        # We need to add a method to get files by directory prefix
+        async with db.acquire() as conn:
+            rows = await conn.fetchall(
+                "SELECT id, file_path FROM files WHERE file_path LIKE ? || '/%' OR file_path = ?",
+                (str(base_path), str(base_path))
+            )
+
+            for row in rows:
+                file_path = Path(row["file_path"])
+
+                if not config.should_include(file_path, base_path):
+                    # File should be excluded, delete it
+                    await conn.execute("DELETE FROM files WHERE id = ?", (row["id"],))
+                    removed_count += 1
+                    logger.info(sm("Removed excluded file from index",
+                                  file_path=str(file_path)))
+
+    logger.info(sm("Cleanup completed", removed_count=removed_count))
+    return removed_count

--- a/packages/cosma-backend/src/cosma_backend/api/watch.py
+++ b/packages/cosma-backend/src/cosma_backend/api/watch.py
@@ -109,16 +109,24 @@ class DeleteJobResponse:
 async def delete_job(job_id: int) -> tuple[DeleteJobResponse, int]:
     """
     Delete a watched directory job by ID.
-    
+
     DELETE /api/watch/jobs/{job_id}
-    
+
+    This will:
+    1. Stop the active watcher job (if running)
+    2. Delete all indexed files for this directory from the database
+    3. Remove the watched directory record
+
     Returns:
         200: Job deleted successfully
         404: Job not found
     """
-    # Delete the watched directory from database
+    # First, stop the watcher job if it's running
+    await current_app.watcher.stop_watching_by_id(job_id)
+
+    # Then delete the watched directory and files from database
     deleted_dir = await current_app.db.delete_watched_directory(job_id)
-    
+
     if deleted_dir:
         return DeleteJobResponse(
             success=True,

--- a/packages/cosma-backend/src/cosma_backend/app.py
+++ b/packages/cosma-backend/src/cosma_backend/app.py
@@ -24,6 +24,7 @@ from cosma_backend.parser import FileParser
 from cosma_backend.summarizer import AutoSummarizer
 from cosma_backend.embedder import AutoEmbedder
 from cosma_backend.watcher import Watcher
+from cosma_backend.filter import FilterConfigManager
 
 load_dotenv()
 
@@ -41,13 +42,15 @@ class App(Quart):
     pipeline: Pipeline
     searcher: HybridSearcher
     watcher: Watcher
+    filter_manager: FilterConfigManager
     dirs: PlatformDirs
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.updates_hub = Hub()
-        self.jobs = set()      
+        self.jobs = set()
+        self.filter_manager = FilterConfigManager()      
 
     def initialize_config(self):
         logger.info("Loading config")
@@ -135,13 +138,22 @@ app.register_blueprint(api_blueprint, url_prefix='/api')
 async def initialize_services():
     logger.info(sm("Initializing database"))
     app.db = await db.connect(app.config['DATABASE_PATH'])
-    
+
+    logger.info(sm("Initializing filter configuration"))
+    # Load global filter config (creates default if not exists)
+    global_config = app.filter_manager.global_config
+    logger.info(sm("Filter config loaded",
+                  mode=global_config.mode.value,
+                  exclude_count=len(global_config.exclude),
+                  include_count=len(global_config.include),
+                  config_path=str(global_config.config_path)))
+
     logger.info(sm("Initializing services"))
     discoverer = Discoverer()
     parser = FileParser(config=app.config)
     summarizer = AutoSummarizer(config=app.config)
     embedder = AutoEmbedder(config=app.config)
-    
+
     app.pipeline = Pipeline(
         db=app.db,
         updates_hub=app.updates_hub,
@@ -150,19 +162,88 @@ async def initialize_services():
         summarizer=summarizer,
         embedder=embedder,
     )
-    
+
     app.searcher = HybridSearcher(
         db=app.db,
         embedder=embedder,
     )
-    
+
     app.watcher = Watcher(
         db=app.db,
         pipeline=app.pipeline,
+        filter_manager=app.filter_manager,
     )
+
+    # Run startup cleanup to remove excluded files from database
+    logger.info(sm("Running startup cleanup for excluded files"))
+    removed_count = await cleanup_excluded_files_on_startup(app.db, app.filter_manager)
+    if removed_count > 0:
+        logger.info(sm("Startup cleanup complete", removed_files=removed_count))
+
     await app.watcher.initialize_from_database()
-    
+
     logger.info(sm("Initialized services"))
+
+
+async def cleanup_excluded_files_on_startup(db: Database, filter_manager: FilterConfigManager) -> int:
+    """
+    Remove files from the database that:
+    1. Match current exclusion patterns (or don't match whitelist in whitelist mode)
+    2. Are not under any active watched directory (orphaned files)
+    Called on server startup.
+
+    Returns:
+        Number of files removed
+    """
+    watched_dirs = await db.get_watched_directories(active_only=True)
+    removed_count = 0
+
+    # Step 1: Clean up orphaned files (not under any active watched directory)
+    async with db.acquire() as conn:
+        all_files = await conn.fetchall("SELECT id, file_path FROM files")
+
+        for row in all_files:
+            file_path = row["file_path"]
+            is_under_watched = False
+
+            for watched_dir in watched_dirs:
+                watched_path = str(watched_dir.path)
+                if file_path.startswith(watched_path + "/") or file_path == watched_path:
+                    is_under_watched = True
+                    break
+
+            if not is_under_watched:
+                await conn.execute("DELETE FROM files WHERE id = ?", (row["id"],))
+                removed_count += 1
+                logger.info(sm("Removed orphaned file from index (not under any watched directory)",
+                              file_path=file_path))
+
+    if not watched_dirs:
+        return removed_count
+
+    # Step 2: Clean up excluded files under watched directories
+    for watched_dir in watched_dirs:
+        base_path = watched_dir.path
+        config = filter_manager.get_config_for_directory(base_path)
+
+        # Get all files under this directory from database
+        async with db.acquire() as conn:
+            rows = await conn.fetchall(
+                "SELECT id, file_path FROM files WHERE file_path LIKE ? || '/%' OR file_path = ?",
+                (str(base_path), str(base_path))
+            )
+
+            for row in rows:
+                file_path = Path(row["file_path"])
+
+                if not config.should_include(file_path, base_path):
+                    # File should be excluded, delete it
+                    await conn.execute("DELETE FROM files WHERE id = ?", (row["id"],))
+                    removed_count += 1
+                    logger.info(sm("Removed excluded file from index",
+                                  file_path=str(file_path)))
+
+    return removed_count
 
 
 @app.after_serving

--- a/packages/cosma-backend/src/cosma_backend/discoverer/discoverer.py
+++ b/packages/cosma-backend/src/cosma_backend/discoverer/discoverer.py
@@ -1,34 +1,70 @@
 from collections.abc import Generator
 from datetime import datetime
+import logging
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
+from cosma_backend.logging import sm
 from cosma_backend.models import File
+
+if TYPE_CHECKING:
+    from cosma_backend.filter import FilterConfig
+
+logger = logging.getLogger(__name__)
 
 
 class Discoverer:
     """A simple file discoverer that recursively finds files under a given path."""
-        
-    
-    def files_in(self, path: str | Path) -> Generator[File, None, None]:
+
+
+    def files_in(
+        self,
+        path: str | Path,
+        filter_config: Optional["FilterConfig"] = None
+    ) -> Generator[File, None, None]:
         """
         Discover all files under the specified path.
-        
+
         Args:
             path: The root path to start discovery from
-            
+            filter_config: Optional filter config to exclude files
+
         Yields:
-            File: Each file found under the specified path
+            File: Each file found under the specified path (excluding filtered files)
         """
-        root = Path(path)
-        
+        root = Path(path).resolve()
+
         if not root.exists():
             return
-        
+
         if root.is_file():
+            # Single file - check filter
+            if filter_config is not None:
+                if not filter_config.should_include(root, root.parent):
+                    logger.debug(sm("Skipping excluded file", file=str(root)))
+                    return
             yield File.from_path(root)
             return
-        
+
+        # Track counts for logging
+        discovered_count = 0
+        filtered_count = 0
+
         # Recursively discover all files
         for item in root.rglob("*"):
             if item.is_file():
+                # Check filter before yielding
+                if filter_config is not None:
+                    if not filter_config.should_include(item, root):
+                        filtered_count += 1
+                        logger.debug(sm("Skipping excluded file", file=str(item)))
+                        continue
+
+                discovered_count += 1
                 yield File.from_path(item)
+
+        if filter_config is not None:
+            logger.info(sm("Discovery complete",
+                          path=str(root),
+                          discovered=discovered_count,
+                          filtered=filtered_count))

--- a/packages/cosma-backend/src/cosma_backend/filter/__init__.py
+++ b/packages/cosma-backend/src/cosma_backend/filter/__init__.py
@@ -1,0 +1,10 @@
+"""
+Filter Module
+
+Provides file filtering functionality based on configurable patterns.
+Supports both blacklist (exclude matching) and whitelist (only include matching) modes.
+"""
+
+from .filter_config import FilterConfig, FilterMode, FilterConfigManager
+
+__all__ = ['FilterConfig', 'FilterMode', 'FilterConfigManager']

--- a/packages/cosma-backend/src/cosma_backend/filter/filter_config.py
+++ b/packages/cosma-backend/src/cosma_backend/filter/filter_config.py
@@ -1,0 +1,778 @@
+"""
+Filter Configuration Module
+
+Handles loading, saving, and applying file filter patterns.
+Supports gitignore-style patterns with blacklist/whitelist modes.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+from platformdirs import PlatformDirs
+
+from cosma_backend.logging import sm
+
+logger = logging.getLogger(__name__)
+
+# Config file names
+GLOBAL_CONFIG_FILENAME = "filter.json"  # Global config in app data dir
+LOCAL_CONFIG_FILENAME = ".cosmaconfig"   # Per-folder config
+
+# App directories (same as used by app.py and tui)
+APP_DIRS = PlatformDirs("cosma", ensure_exists=True)
+
+
+class FilterMode(str, Enum):
+    """Filter mode determines base behavior."""
+    BLACKLIST = "blacklist"  # Exclude matching files (default)
+    WHITELIST = "whitelist"  # Only include matching files
+
+
+# Default patterns for blacklist mode
+DEFAULT_EXCLUDE_PATTERNS = [
+    # Hidden files and directories
+    ".*",
+
+    # Version control
+    ".git/",
+    ".svn/",
+    ".hg/",
+
+    # Dependencies and virtual environments
+    "node_modules/",
+    "vendor/",
+    "venv/",
+    ".venv/",
+    "__pycache__/",
+    "*.egg-info/",
+
+    # Build outputs and compiled files
+    "build/",
+    "dist/",
+    "target/",
+    "*.pyc",
+    "*.pyo",
+    "*.class",
+    "*.o",
+    "*.so",
+    "*.dylib",
+
+    # IDE and editor files
+    ".idea/",
+    ".vscode/",
+    "*.swp",
+    "*.swo",
+    "*~",
+
+    # OS files
+    ".DS_Store",
+    "Thumbs.db",
+    "desktop.ini",
+
+    # Logs and caches
+    "*.log",
+    "*.cache",
+    ".cache/",
+    ".pytest_cache/",
+
+    # Secrets and sensitive files
+    ".env",
+    "*.pem",
+    "*.key",
+    "*.p12",
+]
+
+DEFAULT_INCLUDE_PATTERNS = [
+    # Common exceptions - files we usually want to index even if they start with .
+    ".gitignore",
+    ".env.example",
+]
+
+
+@dataclass
+class FilterConfig:
+    """
+    Configuration for file filtering.
+
+    Supports both global config and per-folder config.
+    Per-folder configs extend (not replace) global patterns.
+
+    NEW: Stores separate pattern lists for each mode to prevent data loss
+    when switching modes. When mode changes, patterns switch to the
+    appropriate list without semantic confusion.
+    """
+    mode: FilterMode = FilterMode.BLACKLIST
+
+    # Mode-specific pattern storage (NEW)
+    blacklist_exclude: list[str] = field(default_factory=list)
+    blacklist_include: list[str] = field(default_factory=list)
+    whitelist_include: list[str] = field(default_factory=list)
+    whitelist_exclude: list[str] = field(default_factory=list)
+
+    # Legacy fields for backward compatibility (deprecated)
+    # These are auto-populated based on current mode
+    exclude: list[str] = field(default_factory=list)
+    include: list[str] = field(default_factory=list)
+
+    version: int = 2  # Bumped to version 2 for new structure
+    config_path: Optional[Path] = None
+
+    # Cached compiled patterns for performance
+    _exclude_regex: Optional[re.Pattern] = field(default=None, repr=False, compare=False)
+    _include_regex: Optional[re.Pattern] = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self):
+        """Compile patterns after initialization."""
+        # Sync legacy fields with mode-specific fields
+        self._sync_legacy_fields()
+        self._compile_patterns()
+
+    def _sync_legacy_fields(self):
+        """Sync legacy exclude/include fields with mode-specific fields."""
+        if self.mode == FilterMode.BLACKLIST:
+            self.exclude = self.blacklist_exclude
+            self.include = self.blacklist_include
+        else:  # WHITELIST
+            self.exclude = self.whitelist_exclude
+            self.include = self.whitelist_include
+
+    def _compile_patterns(self):
+        """Compile glob patterns to regex for efficient matching."""
+        if self.exclude:
+            self._exclude_regex = self._patterns_to_regex(self.exclude)
+        else:
+            self._exclude_regex = None
+
+        if self.include:
+            self._include_regex = self._patterns_to_regex(self.include)
+        else:
+            self._include_regex = None
+
+    @staticmethod
+    def _pattern_to_regex(pattern: str) -> str:
+        """
+        Convert a single glob pattern to regex.
+
+        Supports gitignore-style patterns:
+        - * matches any characters except /
+        - ** matches any characters including /
+        - ? matches single character
+        - / at end means directory
+        - / at start means from root
+        - .* means files/directories starting with dot (hidden items)
+        """
+        original_pattern = pattern
+
+        # Handle directory patterns (trailing /)
+        is_directory = pattern.endswith("/")
+        if is_directory:
+            pattern = pattern[:-1]
+
+        # Handle root-relative patterns (leading /)
+        is_root_relative = pattern.startswith("/")
+        if is_root_relative:
+            pattern = pattern[1:]
+
+        # Special case: ".*" pattern for hidden files/directories
+        # This should match:
+        # 1. Files starting with dot (e.g., .env, .gitignore)
+        # 2. Directories starting with dot (e.g., .git)
+        # 3. All contents inside directories starting with dot (e.g., .git/config)
+        if pattern == ".*":
+            # Match: hidden file OR path containing hidden directory
+            return r"(?:^|.*/)\.[^/]+(?:/.*)?$"
+
+        # Convert glob pattern to regex character by character
+        regex = ""
+        i = 0
+        while i < len(pattern):
+            c = pattern[i]
+            if c == "*":
+                # Check for **
+                if i + 1 < len(pattern) and pattern[i + 1] == "*":
+                    # ** matches anything including /
+                    # Check for /**/ pattern
+                    if i + 2 < len(pattern) and pattern[i + 2] == "/":
+                        regex += "(?:.*/)?"  # Match any path segment or nothing
+                        i += 3
+                        continue
+                    else:
+                        regex += ".*"
+                        i += 2
+                        continue
+                else:
+                    regex += "[^/]*"  # * matches anything except /
+            elif c == "?":
+                regex += "[^/]"  # ? matches single char except /
+            elif c in ".^$+{}[]|()":
+                regex += "\\" + c  # Escape special chars
+            else:
+                regex += c
+            i += 1
+
+        # Add anchoring based on pattern type
+        if is_directory:
+            # Directory pattern: match the directory name anywhere in path
+            # or match anything under that directory
+            # e.g., "node_modules/" should match:
+            # - /path/to/node_modules
+            # - /path/to/node_modules/anything
+            # - node_modules (at root)
+            regex = f"(?:^{regex}(?:/.*)?$|.*/{regex}(?:/.*)?$)"
+        else:
+            # File pattern
+            if "/" in pattern or is_root_relative:
+                # Path pattern - must match from position
+                if is_root_relative:
+                    regex = "^" + regex + "$"
+                else:
+                    regex = "(?:^|.*/)" + regex + "$"
+            else:
+                # Simple filename pattern - match the filename part
+                # e.g., "*.pyc" should match any .pyc file
+                # e.g., ".env" should match exactly .env file
+                regex = "(?:^|.*/)" + regex + "$"
+
+        return regex
+
+    @staticmethod
+    def _patterns_to_regex(patterns: list[str]) -> re.Pattern:
+        """Combine multiple patterns into a single regex."""
+        if not patterns:
+            return re.compile("^$")  # Match nothing
+
+        regex_parts = [FilterConfig._pattern_to_regex(p) for p in patterns]
+        combined = "|".join(f"(?:{r})" for r in regex_parts)
+        return re.compile(combined, re.IGNORECASE)  # macOS is case-insensitive
+
+    def _matches_patterns(self, relative_path: str, regex: Optional[re.Pattern]) -> bool:
+        """Check if path matches compiled regex patterns."""
+        if regex is None:
+            return False
+        return regex.search(relative_path) is not None
+
+    def should_include(self, file_path: Path, base_path: Path) -> bool:
+        """
+        Determine if a file should be included based on filter config.
+
+        Args:
+            file_path: Absolute path to the file
+            base_path: Base directory (watched directory root)
+
+        Returns:
+            True if file should be indexed, False if excluded
+        """
+        try:
+            # Get path relative to base directory
+            relative_path = str(file_path.relative_to(base_path))
+        except ValueError:
+            # File is not under base_path, use filename only
+            relative_path = file_path.name
+
+        # Also check against just the filename for simple patterns
+        filename = file_path.name
+
+        if self.mode == FilterMode.BLACKLIST:
+            # Blacklist mode: Include all, then exclude matching, then include exceptions
+
+            # Check if excluded by any exclude pattern
+            is_excluded = (
+                self._matches_patterns(relative_path, self._exclude_regex) or
+                self._matches_patterns(filename, self._exclude_regex)
+            )
+
+            if not is_excluded:
+                return True  # Not excluded, include it
+
+            # Check if there's an include exception
+            is_included = (
+                self._matches_patterns(relative_path, self._include_regex) or
+                self._matches_patterns(filename, self._include_regex)
+            )
+
+            return is_included  # Include only if there's an exception
+
+        else:  # WHITELIST mode
+            # Whitelist mode: Exclude all, then include matching, then exclude specific
+
+            # Check if included by any include pattern
+            is_included = (
+                self._matches_patterns(relative_path, self._include_regex) or
+                self._matches_patterns(filename, self._include_regex)
+            )
+
+            if not is_included:
+                return False  # Not in whitelist, exclude it
+
+            # Check if there's an exclude exception
+            is_excluded = (
+                self._matches_patterns(relative_path, self._exclude_regex) or
+                self._matches_patterns(filename, self._exclude_regex)
+            )
+
+            return not is_excluded  # Include only if not explicitly excluded
+
+    def to_dict(self) -> dict:
+        """Convert config to dictionary for JSON serialization."""
+        return {
+            "version": self.version,
+            "mode": self.mode.value,
+            # Mode-specific patterns
+            "blacklist_exclude": self.blacklist_exclude,
+            "blacklist_include": self.blacklist_include,
+            "whitelist_include": self.whitelist_include,
+            "whitelist_exclude": self.whitelist_exclude,
+            # Legacy fields for backward compatibility
+            "exclude": self.exclude,
+            "include": self.include,
+        }
+
+    def to_json(self, indent: int = 2) -> str:
+        """Convert config to JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+    @classmethod
+    def from_dict(cls, data: dict, config_path: Optional[Path] = None) -> FilterConfig:
+        """Create FilterConfig from dictionary with migration from v1 to v2."""
+        mode_str = data.get("mode", "blacklist")
+        try:
+            mode = FilterMode(mode_str)
+        except ValueError:
+            logger.warning(sm("Invalid filter mode, defaulting to blacklist", mode=mode_str))
+            mode = FilterMode.BLACKLIST
+
+        version = data.get("version", 1)
+
+        # Migration from version 1 to version 2
+        if version == 1:
+            logger.info(sm("Migrating filter config from v1 to v2", path=str(config_path) if config_path else "unknown"))
+
+            # In v1, we only had exclude/include without mode-specific storage
+            # Migrate based on current mode
+            old_exclude = data.get("exclude", [])
+            old_include = data.get("include", [])
+
+            # Default whitelist patterns (common file types)
+            default_whitelist = [
+                "*.pdf", "*.docx", "*.doc", "*.pptx", "*.ppt", "*.xlsx", "*.xls",
+                "*.odt", "*.ods", "*.odp", "*.pages", "*.numbers", "*.key",
+                "*.png", "*.jpg", "*.jpeg", "*.tiff", "*.bmp", "*.heic", "*.gif", "*.webp",
+                "*.svg", "*.ico", "*.psd",
+                "*.mp3", "*.wav", "*.aac", "*.m4a", "*.flac", "*.ogg",
+                "*.mp4", "*.avi", "*.mov", "*.mkv", "*.wmv", "*.flv", "*.webm",
+                "*.html", "*.htm", "*.txt", "*.csv", "*.json", "*.xml", "*.md",
+                "*.rtf", "*.log",
+                "*.yaml", "*.yml", "*.toml", "*.ini", "*.cfg",
+                "*.tex", "*.rst", "*.adoc",
+                "*.zip", "*.epub", "*.rar", "*.7z", "*.tar", "*.gz",
+                "*.py", "*.js", "*.java", "*.cpp", "*.c", "*.go", "*.rs", "*.sql", "*.sh",
+                "*.eml", "*.msg",
+                "*.dwg", "*.dxf", "*.skp",
+            ]
+
+            if mode == FilterMode.BLACKLIST:
+                # Old patterns were for blacklist mode
+                blacklist_exclude = old_exclude
+                blacklist_include = old_include
+                # Initialize whitelist with sensible defaults
+                whitelist_include = default_whitelist
+                whitelist_exclude = []
+            else:
+                # Old patterns were for whitelist mode
+                whitelist_include = old_include if old_include else default_whitelist
+                whitelist_exclude = old_exclude
+                # Initialize blacklist with defaults
+                blacklist_exclude = DEFAULT_EXCLUDE_PATTERNS.copy()
+                blacklist_include = DEFAULT_INCLUDE_PATTERNS.copy()
+
+            return cls(
+                version=2,  # Upgrade to v2
+                mode=mode,
+                blacklist_exclude=blacklist_exclude,
+                blacklist_include=blacklist_include,
+                whitelist_include=whitelist_include,
+                whitelist_exclude=whitelist_exclude,
+                config_path=config_path,
+            )
+
+        # Version 2+ format
+        return cls(
+            version=version,
+            mode=mode,
+            blacklist_exclude=data.get("blacklist_exclude", []),
+            blacklist_include=data.get("blacklist_include", []),
+            whitelist_include=data.get("whitelist_include", []),
+            whitelist_exclude=data.get("whitelist_exclude", []),
+            config_path=config_path,
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str, config_path: Optional[Path] = None) -> FilterConfig:
+        """Create FilterConfig from JSON string."""
+        try:
+            data = json.loads(json_str)
+            return cls.from_dict(data, config_path)
+        except json.JSONDecodeError as e:
+            logger.error(sm("Failed to parse filter config JSON", error=str(e)))
+            raise ValueError(f"Invalid JSON in filter config: {e}")
+
+    @classmethod
+    def load_from_file(cls, path: Path) -> Optional[FilterConfig]:
+        """
+        Load FilterConfig from a .cosmaconfig file.
+
+        Args:
+            path: Path to the config file
+
+        Returns:
+            FilterConfig if file exists and is valid, None otherwise
+        """
+        if not path.exists():
+            logger.debug(sm("Config file not found", path=str(path)))
+            return None
+
+        try:
+            content = path.read_text(encoding="utf-8")
+            config = cls.from_json(content, config_path=path)
+            logger.info(sm("Loaded filter config", path=str(path), mode=config.mode.value,
+                          exclude_count=len(config.exclude), include_count=len(config.include)))
+            return config
+        except Exception as e:
+            logger.error(sm("Failed to load filter config", path=str(path), error=str(e)))
+            return None
+
+    def save_to_file(self, path: Optional[Path] = None) -> bool:
+        """
+        Save FilterConfig to a .cosmaconfig file.
+
+        Args:
+            path: Path to save to (uses self.config_path if not provided)
+
+        Returns:
+            True if saved successfully, False otherwise
+        """
+        save_path = path or self.config_path
+        if save_path is None:
+            logger.error(sm("No path specified for saving filter config"))
+            return False
+
+        try:
+            # Ensure parent directory exists
+            save_path.parent.mkdir(parents=True, exist_ok=True)
+
+            save_path.write_text(self.to_json(), encoding="utf-8")
+            self.config_path = save_path
+            logger.info(sm("Saved filter config", path=str(save_path)))
+            return True
+        except Exception as e:
+            logger.error(sm("Failed to save filter config", path=str(save_path), error=str(e)))
+            return False
+
+    @classmethod
+    def get_default_global_path(cls) -> Path:
+        """Get the default path for global config.
+
+        Returns path in app data directory:
+        - macOS: ~/Library/Application Support/cosma/filter.json
+        - Linux: ~/.local/share/cosma/filter.json
+        - Windows: C:/Users/<user>/AppData/Local/cosma/filter.json
+        """
+        return Path(APP_DIRS.user_data_dir) / GLOBAL_CONFIG_FILENAME
+
+    @classmethod
+    def load_global(cls) -> FilterConfig:
+        """
+        Load global filter config, creating default if not exists.
+
+        Returns:
+            FilterConfig instance (default if file doesn't exist)
+        """
+        global_path = cls.get_default_global_path()
+
+        config = cls.load_from_file(global_path)
+        if config is not None:
+            return config
+
+        # Create default config with sensible defaults for both modes
+        logger.info(sm("Creating default global filter config", path=str(global_path)))
+
+        # Default whitelist patterns (common document and media types)
+        default_whitelist_include = [
+            # Documents
+            "*.pdf", "*.docx", "*.doc", "*.pptx", "*.ppt", "*.xlsx", "*.xls",
+            "*.odt", "*.ods", "*.odp", "*.pages", "*.numbers", "*.key",
+            # Images
+            "*.png", "*.jpg", "*.jpeg", "*.tiff", "*.bmp", "*.heic", "*.gif", "*.webp",
+            "*.svg", "*.ico", "*.psd",
+            # Audio
+            "*.mp3", "*.wav", "*.aac", "*.m4a", "*.flac", "*.ogg",
+            # Video
+            "*.mp4", "*.avi", "*.mov", "*.mkv", "*.wmv", "*.flv", "*.webm",
+            # Text and Web
+            "*.html", "*.htm", "*.txt", "*.csv", "*.json", "*.xml", "*.md",
+            "*.rtf", "*.log",
+            # Config
+            "*.yaml", "*.yml", "*.toml", "*.ini", "*.cfg",
+            # Technical docs
+            "*.tex", "*.rst", "*.adoc",
+            # Archives
+            "*.zip", "*.epub", "*.rar", "*.7z", "*.tar", "*.gz",
+            # Code
+            "*.py", "*.js", "*.java", "*.cpp", "*.c", "*.go", "*.rs", "*.sql", "*.sh",
+            # Email
+            "*.eml", "*.msg",
+            # Design/CAD
+            "*.dwg", "*.dxf", "*.skp",
+        ]
+
+        config = cls(
+            version=2,
+            mode=FilterMode.BLACKLIST,
+            blacklist_exclude=DEFAULT_EXCLUDE_PATTERNS.copy(),
+            blacklist_include=DEFAULT_INCLUDE_PATTERNS.copy(),
+            whitelist_include=default_whitelist_include,
+            whitelist_exclude=[],
+            config_path=global_path,
+        )
+        config.save_to_file()
+        return config
+
+    @classmethod
+    def load_for_directory(cls, directory: Path, global_config: Optional[FilterConfig] = None) -> FilterConfig:
+        """
+        Load merged config for a specific directory.
+
+        Merges global config with per-folder .cosmaconfig if present.
+        Per-folder patterns extend global patterns.
+        Per-folder mode is ignored (global mode always applies).
+
+        Args:
+            directory: Directory to load config for
+            global_config: Optional pre-loaded global config
+
+        Returns:
+            Merged FilterConfig
+        """
+        # Load global config if not provided
+        if global_config is None:
+            global_config = cls.load_global()
+
+        # Check for per-folder config (.cosmaconfig in the watched directory)
+        folder_config_path = directory / LOCAL_CONFIG_FILENAME
+        folder_config = cls.load_from_file(folder_config_path)
+
+        if folder_config is None:
+            # No per-folder config, use global
+            logger.debug(sm("Using global config for directory", directory=str(directory)))
+            return global_config
+
+        # Merge configs: per-folder extends global
+        # Mode comes from global only
+        merged_exclude = list(global_config.exclude)
+        merged_include = list(global_config.include)
+
+        # Add per-folder patterns (avoid duplicates)
+        for pattern in folder_config.exclude:
+            if pattern not in merged_exclude:
+                merged_exclude.append(pattern)
+
+        for pattern in folder_config.include:
+            if pattern not in merged_include:
+                merged_include.append(pattern)
+
+        merged = cls(
+            mode=global_config.mode,  # Mode always from global
+            exclude=merged_exclude,
+            include=merged_include,
+            config_path=folder_config_path,
+        )
+
+        logger.info(sm("Merged filter config for directory",
+                      directory=str(directory),
+                      mode=merged.mode.value,
+                      exclude_count=len(merged.exclude),
+                      include_count=len(merged.include)))
+
+        return merged
+
+    def merge_with(self, other: FilterConfig) -> FilterConfig:
+        """
+        Create a new config that merges this config with another.
+
+        The other config's patterns extend this config's patterns.
+        Mode is kept from this config (self).
+
+        Args:
+            other: Config to merge with
+
+        Returns:
+            New merged FilterConfig
+        """
+        merged_exclude = list(self.exclude)
+        merged_include = list(self.include)
+
+        for pattern in other.exclude:
+            if pattern not in merged_exclude:
+                merged_exclude.append(pattern)
+
+        for pattern in other.include:
+            if pattern not in merged_include:
+                merged_include.append(pattern)
+
+        return FilterConfig(
+            mode=self.mode,
+            exclude=merged_exclude,
+            include=merged_include,
+            config_path=other.config_path or self.config_path,
+        )
+
+
+class FilterConfigManager:
+    """
+    Manages filter configurations for multiple directories.
+
+    Caches loaded configs and handles reloading on config file changes.
+    """
+
+    def __init__(self):
+        self._global_config: Optional[FilterConfig] = None
+        self._directory_configs: dict[Path, FilterConfig] = {}
+
+    @property
+    def global_config(self) -> FilterConfig:
+        """Get the global config, loading if necessary."""
+        if self._global_config is None:
+            self._global_config = FilterConfig.load_global()
+        return self._global_config
+
+    def reload_global(self) -> FilterConfig:
+        """Force reload of global config."""
+        self._global_config = FilterConfig.load_global()
+        # Invalidate all directory configs since they depend on global
+        self._directory_configs.clear()
+        return self._global_config
+
+    def get_config_for_directory(self, directory: Path) -> FilterConfig:
+        """
+        Get the merged config for a directory.
+
+        Uses cached config if available.
+        """
+        directory = directory.resolve()
+
+        if directory not in self._directory_configs:
+            self._directory_configs[directory] = FilterConfig.load_for_directory(
+                directory, self.global_config
+            )
+
+        return self._directory_configs[directory]
+
+    def reload_directory(self, directory: Path) -> FilterConfig:
+        """Force reload of config for a specific directory."""
+        directory = directory.resolve()
+        self._directory_configs[directory] = FilterConfig.load_for_directory(
+            directory, self.global_config
+        )
+        return self._directory_configs[directory]
+
+    def invalidate_directory(self, directory: Path):
+        """Remove cached config for a directory."""
+        directory = directory.resolve()
+        self._directory_configs.pop(directory, None)
+
+    def update_global_config(
+        self,
+        mode: Optional[FilterMode] = None,
+        exclude: Optional[list[str]] = None,
+        include: Optional[list[str]] = None,
+        # New mode-specific parameters
+        blacklist_exclude: Optional[list[str]] = None,
+        blacklist_include: Optional[list[str]] = None,
+        whitelist_include: Optional[list[str]] = None,
+        whitelist_exclude: Optional[list[str]] = None,
+    ) -> FilterConfig:
+        """
+        Update the global config.
+
+        Args:
+            mode: New filter mode (or keep existing)
+            exclude: Legacy exclude patterns (deprecated - use mode-specific params)
+            include: Legacy include patterns (deprecated - use mode-specific params)
+            blacklist_exclude: Patterns to exclude in blacklist mode
+            blacklist_include: Patterns to include in blacklist mode
+            whitelist_include: Patterns to include in whitelist mode
+            whitelist_exclude: Patterns to exclude in whitelist mode
+
+        Returns:
+            Updated global config
+        """
+        config = self.global_config
+
+        # Determine new mode
+        new_mode = mode if mode is not None else config.mode
+
+        # Handle mode-specific updates
+        if blacklist_exclude is not None or blacklist_include is not None or \
+           whitelist_include is not None or whitelist_exclude is not None:
+            # Using new API with mode-specific patterns
+            new_config = FilterConfig(
+                mode=new_mode,
+                blacklist_exclude=blacklist_exclude if blacklist_exclude is not None else config.blacklist_exclude,
+                blacklist_include=blacklist_include if blacklist_include is not None else config.blacklist_include,
+                whitelist_include=whitelist_include if whitelist_include is not None else config.whitelist_include,
+                whitelist_exclude=whitelist_exclude if whitelist_exclude is not None else config.whitelist_exclude,
+                config_path=config.config_path,
+            )
+        else:
+            # Using legacy API (exclude/include) - apply to current mode's patterns
+            new_blacklist_exclude = config.blacklist_exclude
+            new_blacklist_include = config.blacklist_include
+            new_whitelist_include = config.whitelist_include
+            new_whitelist_exclude = config.whitelist_exclude
+
+            if exclude is not None or include is not None:
+                if new_mode == FilterMode.BLACKLIST:
+                    new_blacklist_exclude = exclude if exclude is not None else config.blacklist_exclude
+                    new_blacklist_include = include if include is not None else config.blacklist_include
+                else:  # WHITELIST
+                    new_whitelist_exclude = exclude if exclude is not None else config.whitelist_exclude
+                    new_whitelist_include = include if include is not None else config.whitelist_include
+
+            new_config = FilterConfig(
+                mode=new_mode,
+                blacklist_exclude=new_blacklist_exclude,
+                blacklist_include=new_blacklist_include,
+                whitelist_include=new_whitelist_include,
+                whitelist_exclude=new_whitelist_exclude,
+                config_path=config.config_path,
+            )
+
+        new_config.save_to_file()
+        self._global_config = new_config
+
+        # Invalidate all directory configs
+        self._directory_configs.clear()
+
+        return new_config
+
+    def should_include_file(self, file_path: Path, base_directory: Path) -> bool:
+        """
+        Check if a file should be included based on filter config.
+
+        Args:
+            file_path: Path to the file
+            base_directory: The watched directory root
+
+        Returns:
+            True if file should be indexed
+        """
+        config = self.get_config_for_directory(base_directory)
+        return config.should_include(file_path, base_directory)

--- a/packages/cosma-backend/src/cosma_backend/pipeline/pipeline.py
+++ b/packages/cosma-backend/src/cosma_backend/pipeline/pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import TYPE_CHECKING, Any, Iterator, Optional
 import logging
 
 from cosma_backend.db import Database
@@ -15,6 +15,9 @@ from cosma_backend.parser import FileParser
 from cosma_backend.summarizer import AutoSummarizer
 from cosma_backend.embedder import AutoEmbedder
 from cosma_backend.utils.pubsub import Hub
+
+if TYPE_CHECKING:
+    from cosma_backend.filter import FilterConfig
 
 logger = logging.getLogger(__name__)
 
@@ -53,28 +56,34 @@ class Pipeline:
         self.summarizer = summarizer or AutoSummarizer()
         self.embedder = embedder or AutoEmbedder()
     
-    async def process_directory(self, path: str | Path):
+    async def process_directory(
+        self,
+        path: str | Path,
+        filter_config: Optional["FilterConfig"] = None
+    ):
         """
         Process all files in a directory through the full pipeline.
         After processing, deletes any files from the database that weren't seen
         (i.e., files that no longer exist in the filesystem).
-        
+
         Args:
             path: Root directory to process
-            
+            filter_config: Optional filter config to exclude files
+
         Returns:
             PipelineResult with statistics
         """
         # result = PipelineResult()
-        
+
         # Publish directory processing started
         self._publish_update(Update.directory_processing_started(str(path)))
-        
+
         started_processing = datetime.now(timezone.utc)
-        
-        # Stage 1: Discovery
-        logger.info(f"Discovering files in {path}")
-        for file in self.discoverer.files_in(path):
+
+        # Stage 1: Discovery (with filtering)
+        logger.info(sm("Discovering files", path=str(path),
+                      has_filter=filter_config is not None))
+        for file in self.discoverer.files_in(path, filter_config=filter_config):
             # result.discovered += 1
             
             try:

--- a/packages/cosma-backend/src/cosma_backend/watcher/watcher.py
+++ b/packages/cosma-backend/src/cosma_backend/watcher/watcher.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from watchdog.events import (
     FileSystemEvent,
@@ -26,7 +26,13 @@ from cosma_backend.pipeline import Pipeline
 from cosma_backend.utils.pubsub import Hub
 from cosma_backend.watcher.awatchdog import watch
 
+if TYPE_CHECKING:
+    from cosma_backend.filter import FilterConfigManager
+
 logger = logging.getLogger(__name__)
+
+# Per-folder config file name to watch for changes
+LOCAL_CONFIG_FILENAME = ".cosmaconfig"
 
 
 class WatcherJob:
@@ -37,11 +43,19 @@ class WatcherJob:
     observer: Optional[BaseObserver]
     task: Optional[asyncio.Task]
     closed: bool
-    
-    def __init__(self, watched_dir: WatchedDirectory, pipeline: Pipeline, db: Database):
+    filter_manager: Optional["FilterConfigManager"]
+
+    def __init__(
+        self,
+        watched_dir: WatchedDirectory,
+        pipeline: Pipeline,
+        db: Database,
+        filter_manager: Optional["FilterConfigManager"] = None
+    ):
         self.watched_dir = watched_dir
         self.pipeline = pipeline
         self.db = db
+        self.filter_manager = filter_manager
         self.queue = asyncio.Queue()
         self.observer = None
         self.closed = False
@@ -53,7 +67,12 @@ class WatcherJob:
             self.pipeline.updates_hub.publish(update)
             
     async def do_initial_processing(self):
-        await self.pipeline.process_directory(self.watched_dir.path)
+        # Get filter config for this directory
+        filter_config = None
+        if self.filter_manager is not None:
+            filter_config = self.filter_manager.get_config_for_directory(self.watched_dir.path)
+
+        await self.pipeline.process_directory(self.watched_dir.path, filter_config=filter_config)
     
     async def start(self):
         logger.info(sm("Starting watchdog observer", watched_dir=self.watched_dir))
@@ -78,91 +97,200 @@ class WatcherJob:
         if self.observer is not None:
             self.observer.unschedule_all()
         
+    def _should_include_file(self, file_path: Path) -> bool:
+        """Check if file should be included based on filter config."""
+        if self.filter_manager is None:
+            return True
+
+        base_path = self.watched_dir.path
+        return self.filter_manager.should_include_file(file_path, base_path)
+
+    def _is_config_file(self, file_path: Path) -> bool:
+        """Check if the file is a .cosmaconfig file."""
+        return file_path.name == LOCAL_CONFIG_FILENAME
+
+    def _handle_config_change(self, file_path: Path):
+        """Handle changes to .cosmaconfig file."""
+        if self.filter_manager is None:
+            return
+
+        # Check if this is the config file for our watched directory
+        if file_path.parent == self.watched_dir.path:
+            logger.info(sm("Config file changed, reloading filter config",
+                          config_path=str(file_path),
+                          watched_dir=str(self.watched_dir.path)))
+            self.filter_manager.reload_directory(self.watched_dir.path)
+
     async def consumer_task(self):
         while not self.closed:
             event = await self.queue.get()
-            
+
             # Skip directory events - we only care about files
             if isinstance(event, (DirCreatedEvent, DirModifiedEvent, DirDeletedEvent, DirMovedEvent)):
                 logger.debug(sm("Skipping directory event", event_type=type(event).__name__, path=event.src_path))
                 continue
-            
+
             try:
                 # Handle different event types
                 if isinstance(event, FileDeletedEvent):
                     logger.info(sm("File deleted", path=event.src_path))
                     path = Path(str(event.src_path)).resolve()
-                    
+
+                    # Check if config file was deleted
+                    if self._is_config_file(path):
+                        self._handle_config_change(path)
+
                     self._publish_update(Update.file_deleted(str(path)))
                     await self.db.delete_file(str(path))
-                    
+
                 elif isinstance(event, FileMovedEvent):
                     # Handle moved files as delete old + create new
                     logger.info(sm("File moved", src=event.src_path, dest=event.dest_path))
                     src_path = Path(str(event.src_path)).resolve()
                     dest_path = Path(str(event.dest_path)).resolve()
-                    
+
                     self._publish_update(Update.file_moved(str(src_path), str(dest_path)))
                     await self.db.delete_file(str(src_path))
-                    
+
+                    # Check if config file was moved
+                    if self._is_config_file(dest_path):
+                        self._handle_config_change(dest_path)
+                        continue  # Don't index config files
+
+                    # Check filter before processing destination
+                    if not self._should_include_file(dest_path):
+                        logger.debug(sm("Skipping excluded file", path=str(dest_path)))
+                        continue
+
                     # Check if destination file type is supported before processing
                     dest_file = File.from_path(dest_path)
                     if await self.pipeline.is_supported(dest_file):
                         await self.pipeline.process_file(dest_file)
                     else:
                         logger.debug(sm("Skipping unsupported file type", path=str(dest_path)))
-                    
+
                 elif isinstance(event, (FileCreatedEvent, FileModifiedEvent)):
                     # Handle created and modified files the same way - process them
                     event_type = "created" if isinstance(event, FileCreatedEvent) else "modified"
                     logger.info(sm(f"File {event_type}", path=event.src_path))
                     path = Path(str(event.src_path)).resolve()
-                    
+
+                    # Check if config file changed
+                    if self._is_config_file(path):
+                        self._handle_config_change(path)
+                        continue  # Don't index config files
+
+                    # Check filter before processing
+                    if not self._should_include_file(path):
+                        logger.debug(sm("Skipping excluded file", path=str(path)))
+                        continue
+
                     # Publish file system event update
                     if isinstance(event, FileCreatedEvent):
                         self._publish_update(Update.file_created(str(path)))
                     else:
                         self._publish_update(Update.file_modified(str(path)))
-                    
+
                     # Check if file type is supported before processing
                     file = File.from_path(path)
                     if await self.pipeline.is_supported(file):
                         await self.pipeline.process_file(file)
                     else:
                         logger.debug(sm("Skipping unsupported file type", path=str(path)))
-                    
+
                 else:
                     logger.warning(sm("Unknown event type", event_type=type(event).__name__, path=event.src_path))
-                    
+
             except Exception as e:
                 logger.error(sm("Error processing file system event", event_type=type(event).__name__, path=event.src_path, error=e))
     
 
 class Watcher:
     jobs: set[WatcherJob]
-    
+    filter_manager: Optional["FilterConfigManager"]
+
     def __init__(
         self,
         db: Database,
         pipeline: Pipeline,
         updates_hub: Optional[Hub] = None,
+        filter_manager: Optional["FilterConfigManager"] = None,
     ):
         self.db = db
         self.pipeline = pipeline
         self.updates_hub = updates_hub
-        
+        self.filter_manager = filter_manager
+
         self.jobs = set()
 
     async def create_job(self, watched_dir: WatchedDirectory):
         """
         Create and start a watcher job for a watched directory.
-        
+
         Args:
             watched_dir: WatchedDirectory instance to watch
         """
-        job = WatcherJob(watched_dir, self.pipeline, self.db)
+        job = WatcherJob(watched_dir, self.pipeline, self.db, self.filter_manager)
         self.jobs.add(job)
         await job.start()
+
+    async def stop_watching(self, path: Path | str) -> bool:
+        """
+        Stop watching a directory.
+
+        Args:
+            path: Path to the directory to stop watching
+
+        Returns:
+            True if a job was found and stopped, False otherwise
+        """
+        path = Path(path).resolve()
+
+        # Find the job for this path
+        job_to_stop = None
+        for job in self.jobs:
+            if job.watched_dir.path == path:
+                job_to_stop = job
+                break
+
+        if job_to_stop is None:
+            logger.warning(sm("No watcher job found for path", path=str(path)))
+            return False
+
+        # Stop the job
+        await job_to_stop.stop()
+        self.jobs.discard(job_to_stop)
+
+        logger.info(sm("Stopped watching directory", path=str(path)))
+        return True
+
+    async def stop_watching_by_id(self, job_id: int) -> bool:
+        """
+        Stop watching a directory by its database ID.
+
+        Args:
+            job_id: Database ID of the watched directory
+
+        Returns:
+            True if a job was found and stopped, False otherwise
+        """
+        # Find the job for this ID
+        job_to_stop = None
+        for job in self.jobs:
+            if job.watched_dir.id == job_id:
+                job_to_stop = job
+                break
+
+        if job_to_stop is None:
+            logger.warning(sm("No watcher job found for ID", job_id=job_id))
+            return False
+
+        # Stop the job
+        await job_to_stop.stop()
+        self.jobs.discard(job_to_stop)
+
+        logger.info(sm("Stopped watching directory by ID", job_id=job_id, path=str(job_to_stop.watched_dir.path)))
+        return True
 
     async def start_watching(self, path: str | Path, recursive: bool = True, file_pattern: Optional[str] = None):
         """

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "cosma"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click-help-colors" },
@@ -436,7 +436,7 @@ dev = [
 
 [[package]]
 name = "cosma-backend"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/cosma-backend" }
 dependencies = [
     { name = "asqlite" },
@@ -478,7 +478,7 @@ requires-dist = [
     { name = "asqlite", specifier = ">=2.0.0" },
     { name = "litellm", specifier = ">=1.77.5" },
     { name = "llama-cpp-python", marker = "extra == 'llamacpp'", git = "https://github.com/JamePeng/llama-cpp-python" },
-    { name = "markitdown", extras = ["docx", "pdf", "pptx"], specifier = ">=0.1.3" },
+    { name = "markitdown", extras = ["docx", "pdf", "pptx"], specifier = ">=0.1.4" },
     { name = "ollama", specifier = ">=0.6.0" },
     { name = "platformdirs", specifier = ">=4.5.0" },
     { name = "quart", specifier = ">=0.20.0" },
@@ -508,7 +508,7 @@ test = [
 
 [[package]]
 name = "cosma-tui"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/cosma-tui" }
 dependencies = [
     { name = "niquests" },
@@ -1442,7 +1442,7 @@ wheels = [
 
 [[package]]
 name = "markitdown"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1453,9 +1453,9 @@ dependencies = [
     { name = "onnxruntime", marker = "sys_platform == 'win32'" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/31/90cef2bc8ecd85c200ed3b3d1e20fc7a724213502685c4b05b5431e02668/markitdown-0.1.3.tar.gz", hash = "sha256:b0d9127c3373a68274dede6af6c9bb0684b78ce364c727c4c304da97a20d6fd9", size = 40039, upload-time = "2025-08-26T22:37:04.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/4d/06567465c1886c2ea47bac24eab0c96bb6b4ecea47224323409dc9cbb614/markitdown-0.1.4.tar.gz", hash = "sha256:e72a481d1a50c82ff744e85e3289f79a940c5d0ad5ffa2b37c33de814c195bb1", size = 39951, upload-time = "2025-12-01T18:20:30.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/83/7b47d2ecbf58650a03aeeb21ba2d59175f202bf4fb81d44f40f1deb82bc0/markitdown-0.1.3-py3-none-any.whl", hash = "sha256:08d9a25770979d78f60dcc0afcb868de6799608e4db65342b2e03304fb091251", size = 58391, upload-time = "2025-08-26T22:37:02.924Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b3/6138d2b23d5b534b0fa3736987a2e11bcef5419cbc9286c8afd229d21558/markitdown-0.1.4-py3-none-any.whl", hash = "sha256:d7f3805716b22545f693d355e28e89584226c0614b3b80b7c4a3f825f068492d", size = 58314, upload-time = "2025-12-01T18:20:32.345Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
#Implement comprehensive file filtering with blacklist/whitelist modes:

Filter Module:
- Add filter_config.py with FilterConfig dataclass and FilterConfigManager
- Support mode-specific pattern storage (blacklist_exclude, blacklist_include, whitelist_include, whitelist_exclude) to prevent data loss on mode switch
- Config versioning with automatic v1 to v2 migration
- Smart defaults for whitelist mode with 74 common file patterns
- Glob pattern matching with fnmatch

Filter API Endpoints:
- GET/PUT /api/filters/config - retrieve and update filter configuration
- POST /api/filters/apply - explicitly apply filter changes to database
- POST/DELETE /api/filters/pattern - add/remove individual patterns
- POST /api/filters/reset - reset to default configuration
- GET /api/filters/defaults - retrieve default configuration
- Add apply_immediately parameter to control when DB cleanup runs

Startup Cleanup:
- Clean up orphaned files not under any active watched directory
- Clean up files that don't match current filter on startup
- Fix edge case where files remained after watched directory deletion

Integration:
- Integrate filter checks in discoverer, pipeline, and watcher
- Pass filter configuration through file processing pipeline