### PR TITLE
Fix merged filter patterns being discarded during per-folder config init

### DIFF
--- a/packages/cosma-backend/src/cosma_backend/filter/filter_config.py
+++ b/packages/cosma-backend/src/cosma_backend/filter/filter_config.py
@@ -587,12 +587,21 @@ class FilterConfig:
             if pattern not in merged_include:
                 merged_include.append(pattern)
 
-        merged = cls(
-            mode=global_config.mode,  # Mode always from global
-            exclude=merged_exclude,
-            include=merged_include,
-            config_path=folder_config_path,
-        )
+        # Populate mode-specific fields so __post_init__ preserves them
+        if global_config.mode == FilterMode.BLACKLIST:
+            merged = cls(
+                mode=global_config.mode,
+                blacklist_exclude=merged_exclude,
+                blacklist_include=merged_include,
+                config_path=folder_config_path,
+            )
+        else:
+            merged = cls(
+                mode=global_config.mode,
+                whitelist_exclude=merged_exclude,
+                whitelist_include=merged_include,
+                config_path=folder_config_path,
+            )
 
         logger.info("Merged filter config for directory",
                       directory=str(directory),
@@ -626,12 +635,21 @@ class FilterConfig:
             if pattern not in merged_include:
                 merged_include.append(pattern)
 
-        return FilterConfig(
-            mode=self.mode,
-            exclude=merged_exclude,
-            include=merged_include,
-            config_path=other.config_path or self.config_path,
-        )
+        # Populate mode-specific fields so __post_init__ preserves them
+        if self.mode == FilterMode.BLACKLIST:
+            return FilterConfig(
+                mode=self.mode,
+                blacklist_exclude=merged_exclude,
+                blacklist_include=merged_include,
+                config_path=other.config_path or self.config_path,
+            )
+        else:
+            return FilterConfig(
+                mode=self.mode,
+                whitelist_exclude=merged_exclude,
+                whitelist_include=merged_include,
+                config_path=other.config_path or self.config_path,
+            )
 
 
 class FilterConfigManager:


### PR DESCRIPTION
## Summary
- **Bug**: `FilterConfig.load_for_directory` and `merge_with` passed merged patterns via legacy `exclude`/`include` fields, but `__post_init__` overwrites those from mode-specific lists (which were empty), silently discarding all merged patterns.
- **Impact**: Any watched directory with a `.cosmaconfig` would lose both global and per-folder filter patterns, causing files that should be excluded (e.g., `.git/`, `node_modules/`) to be indexed.
- **Fix**: Populate the correct mode-specific fields (`blacklist_exclude`/`blacklist_include` or `whitelist_exclude`/`whitelist_include`) based on the current mode so `_sync_legacy_fields` preserves them.

## Test plan
- [x] Existing filter tests pass (`pytest tests/ -k filter`)
- [ ] Verify that a watched directory with a `.cosmaconfig` correctly excludes `.git/` and `node_modules/`
- [ ] Verify whitelist mode also preserves merged patterns when a per-folder config is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)