### PR TITLE
Fix backend performance: lock contention, event loop blocking, GPU/memory leaks

### DIFF
--- a/packages/cosma-backend/pyproject.toml
+++ b/packages/cosma-backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosma-backend"
-version = "0.5.0"
+version = "0.7.0"
 description = "Cosma backend"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/cosma-backend/src/cosma_backend/api/models.py
+++ b/packages/cosma-backend/src/cosma_backend/api/models.py
@@ -37,3 +37,5 @@ class JobResponse:
     last_scan: datetime | None
     created_at: datetime | None
     updated_at: datetime | None
+    file_count: int = 0        # total indexed files in DB for this directory
+    total_files: int = 0       # total files on disk (from last discovery)

--- a/packages/cosma-backend/src/cosma_backend/api/queue.py
+++ b/packages/cosma-backend/src/cosma_backend/api/queue.py
@@ -236,14 +236,24 @@ async def system_metrics() -> tuple[MetricsResponse, int]:
 # ------------------------------------------------------------------
 
 def _file_to_list_item(f) -> dict[str, Any]:
-    """Convert a File model to a dict suitable for FileListResponse."""
+    """Convert a File model to a dict suitable for FileListResponse.
+
+    `updated_at` is the DB row's last-write time (when we actually processed
+    the file), NOT the filesystem mtime. We fall back to `modified` only if
+    the column is missing (older DBs).
+    """
+    ts = None
+    if getattr(f, "updated_at", None) is not None:
+        ts = int(f.updated_at.timestamp())
+    elif f.modified is not None:
+        ts = int(f.modified.timestamp())
     return {
         "file_path": f.file_path,
         "filename": f.filename,
         "extension": f.extension,
         "processing_error": f.processing_error,
         "status": f.status.name if hasattr(f.status, "name") else str(f.status),
-        "updated_at": int(f.modified.timestamp()) if f.modified else None,
+        "updated_at": ts,
     }
 
 

--- a/packages/cosma-backend/src/cosma_backend/api/settings.py
+++ b/packages/cosma-backend/src/cosma_backend/api/settings.py
@@ -4,12 +4,20 @@ Settings API Blueprint
 Handles endpoints for reading and updating application settings.
 """
 
+import asyncio
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
+import httpx
 from quart import Blueprint, current_app, request
+
+from cosma_backend.logging import get_logger
 
 if TYPE_CHECKING:
     from cosma_backend.app import app as current_app
+
+logger = get_logger(__name__)
 
 settings_bp = Blueprint('settings', __name__)
 
@@ -46,3 +54,191 @@ async def update_settings():
 async def get_defaults():
     """Return default values for all settings."""
     return current_app.settings_manager.defaults()
+
+
+@settings_bp.post("/test_model")
+async def test_model():
+    """
+    Quick availability check for the currently configured summarizer model.
+
+    Does NOT load the model — just verifies the backend is reachable and the
+    model is known to it. Designed to run as a non-blocking background task.
+
+    Response shape:
+        {"ok": true, "provider": "ollama", "model": "...", "detail": "..."}
+        {"ok": false, "provider": "ollama", "model": "...", "detail": "...error..."}
+    """
+    settings = current_app.settings_manager.settings
+    provider = (settings.summarizer.provider or "auto").lower()
+
+    # Resolve "auto" to a concrete provider based on env / fallback
+    effective_provider = provider
+    if provider == "auto":
+        if os.getenv("OPENAI_API_KEY"):
+            effective_provider = "online"
+        else:
+            effective_provider = "ollama"
+
+    try:
+        if effective_provider == "ollama":
+            return await _test_ollama(settings.summarizer.ollama)
+        elif effective_provider == "llamacpp":
+            return await _test_llamacpp(settings.summarizer.llamacpp)
+        elif effective_provider == "online":
+            return await _test_online(settings.summarizer.online)
+        else:
+            return {
+                "ok": False,
+                "provider": effective_provider,
+                "model": "",
+                "detail": f"Unknown summarizer provider: {effective_provider}",
+            }
+    except Exception as e:
+        logger.exception("Model availability test crashed",
+                        provider=effective_provider, error=str(e))
+        return {
+            "ok": False,
+            "provider": effective_provider,
+            "model": "",
+            "detail": f"Internal error during test: {e}",
+        }
+
+
+async def _test_ollama(cfg) -> dict:
+    """Verify Ollama host is reachable and the model is pulled."""
+    model = (cfg.model or "").strip() or "qwen3-vl:2b-instruct"
+    host = (cfg.host or "").strip() or "http://localhost:11434"
+    url = f"{host.rstrip('/')}/api/tags"
+
+    try:
+        async with httpx.AsyncClient(timeout=3.0) as client:
+            resp = await client.get(url)
+    except httpx.HTTPError as e:
+        return {
+            "ok": False,
+            "provider": "ollama",
+            "model": model,
+            "detail": f"Ollama not reachable at {host}: {e}",
+        }
+
+    if resp.status_code != 200:
+        return {
+            "ok": False,
+            "provider": "ollama",
+            "model": model,
+            "detail": f"Ollama returned HTTP {resp.status_code}",
+        }
+
+    try:
+        data = resp.json()
+    except Exception as e:
+        return {
+            "ok": False,
+            "provider": "ollama",
+            "model": model,
+            "detail": f"Invalid Ollama response: {e}",
+        }
+
+    models = [m.get("name", "") for m in data.get("models", [])]
+    # Match exact or by tag prefix (e.g. "qwen3-vl:2b-instruct" vs "qwen3-vl:2b")
+    base_name = model.split(":", 1)[0]
+    has_model = any(
+        m == model or m.startswith(base_name + ":") or m == base_name
+        for m in models
+    )
+
+    if not has_model:
+        return {
+            "ok": False,
+            "provider": "ollama",
+            "model": model,
+            "detail": (
+                f"Ollama is running but '{model}' is not pulled. "
+                f"Run: ollama pull {model}"
+            ),
+        }
+
+    return {
+        "ok": True,
+        "provider": "ollama",
+        "model": model,
+        "detail": f"Ollama model '{model}' is available",
+    }
+
+
+async def _test_llamacpp(cfg) -> dict:
+    """Verify llama.cpp model file is locally present or accessible on HF."""
+    # Prefer local path if set
+    model_path = (cfg.model_path or "").strip()
+    if model_path:
+        if Path(model_path).expanduser().exists():
+            return {
+                "ok": True,
+                "provider": "llamacpp",
+                "model": model_path,
+                "detail": f"Local model file exists at {model_path}",
+            }
+        return {
+            "ok": False,
+            "provider": "llamacpp",
+            "model": model_path,
+            "detail": f"Model path does not exist: {model_path}",
+        }
+
+    repo_id = (cfg.repo_id or "").strip() or "unsloth/Qwen3-VL-2B-Instruct-GGUF"
+    filename = (cfg.filename or "").strip() or "*Q4_K_M.gguf"
+
+    # Check HuggingFace reachability (HEAD on the repo page is lightweight)
+    url = f"https://huggingface.co/api/models/{repo_id}"
+    try:
+        async with httpx.AsyncClient(timeout=5.0, follow_redirects=True) as client:
+            resp = await client.get(url)
+    except httpx.HTTPError as e:
+        return {
+            "ok": False,
+            "provider": "llamacpp",
+            "model": f"{repo_id}/{filename}",
+            "detail": f"Cannot reach HuggingFace for {repo_id}: {e}",
+        }
+
+    if resp.status_code == 404:
+        return {
+            "ok": False,
+            "provider": "llamacpp",
+            "model": f"{repo_id}/{filename}",
+            "detail": f"HuggingFace repo not found: {repo_id}",
+        }
+    if resp.status_code != 200:
+        return {
+            "ok": False,
+            "provider": "llamacpp",
+            "model": f"{repo_id}/{filename}",
+            "detail": f"HuggingFace returned HTTP {resp.status_code} for {repo_id}",
+        }
+
+    return {
+        "ok": True,
+        "provider": "llamacpp",
+        "model": f"{repo_id}/{filename}",
+        "detail": f"HuggingFace repo '{repo_id}' is reachable",
+    }
+
+
+async def _test_online(cfg) -> dict:
+    """Verify online provider has a valid API key configured."""
+    model = (cfg.model or "").strip() or "openai/gpt-4.1-nano-2025-04-14"
+
+    if not os.getenv("OPENAI_API_KEY"):
+        return {
+            "ok": False,
+            "provider": "online",
+            "model": model,
+            "detail": "OPENAI_API_KEY environment variable is not set",
+        }
+
+    return {
+        "ok": True,
+        "provider": "online",
+        "model": model,
+        "detail": f"API key is configured for '{model}'",
+    }

--- a/packages/cosma-backend/src/cosma_backend/api/status.py
+++ b/packages/cosma-backend/src/cosma_backend/api/status.py
@@ -23,6 +23,15 @@ status_bp = Blueprint('status', __name__)
 @status_bp.get("/")  # type: ignore[return-value]
 async def status():
     """Get current application status and active jobs count"""
+    embedder_ready = False
+    searcher = getattr(current_app, "searcher", None)
+    if searcher is not None:
+        embedder = getattr(searcher, "embedder", None)
+        if embedder is not None:
+            embedder_ready = embedder.is_model_loaded()
+    init_progress = getattr(current_app, "_deferred_init_progress", 0.0)
     return {
         "jobs": len(current_app.jobs),
+        "embedder_ready": embedder_ready,
+        "init_progress": round(init_progress, 2),
     }

--- a/packages/cosma-backend/src/cosma_backend/api/watch.py
+++ b/packages/cosma-backend/src/cosma_backend/api/watch.py
@@ -89,10 +89,14 @@ async def get_jobs() -> tuple[JobsListResponse, int]:
     """    
     # Get all watched directories from database
     watched_dirs = await current_app.db.get_watched_directories(active_only=False)
-    
-    # Convert to API response models
-    jobs = [watched_dir.to_response() for watched_dir in watched_dirs]
-    
+
+    # Convert to API response models with file counts
+    jobs = []
+    for watched_dir in watched_dirs:
+        job = watched_dir.to_response()
+        job.file_count = await current_app.db.count_files_in_directory(str(watched_dir.path))
+        jobs.append(job)
+
     return JobsListResponse(jobs=jobs), 200
 
 

--- a/packages/cosma-backend/src/cosma_backend/app.py
+++ b/packages/cosma-backend/src/cosma_backend/app.py
@@ -149,77 +149,86 @@ app.register_blueprint(api_blueprint, url_prefix='/api')
 
 @app.before_serving
 async def initialize_services():
-    logger.info("Initializing database")
+    """Two-phase startup: API-ready first, heavy models load in background.
+
+    Phase 1 (blocking): DB + filter + services created (no model loading)
+           → API is reachable, frontend can connect
+    Phase 2 (background): Load embedding model + start indexing + watcher
+           → Search becomes available, then indexing starts
+    """
+    # ── Phase 1: Fast startup — get the API responding ──
+    logger.info("Phase 1: Initializing database and core services")
     app.db = await db.connect(app.config['DATABASE_PATH'])
 
-    logger.info("Initializing filter configuration")
-    # Load global filter config (creates default if not exists)
     global_config = app.filter_manager.global_config
     logger.info("Filter config loaded",
                   mode=global_config.mode.value,
-                  exclude_count=len(global_config.exclude),
                   include_count=len(global_config.include),
                   config_path=str(global_config.config_path))
 
-    logger.info("Initializing services")
     settings = app.settings_manager.settings
     discoverer = Discoverer()
     parser = FileParser(config=settings.parser)
     summarizer = AutoSummarizer(config=settings.summarizer)
-    embedder = AutoEmbedder(config=settings.embedder)
+
+    # Create embedder WITHOUT eager model loading — stays lazy
+    embedder = AutoEmbedder(config=settings.embedder, preferred_provider="lazy_local")
 
     app.pipeline = Pipeline(
-        db=app.db,
-        updates_hub=app.updates_hub,
-        parser=parser,
-        discoverer=discoverer,
-        summarizer=summarizer,
-        embedder=embedder,
+        db=app.db, updates_hub=app.updates_hub,
+        parser=parser, discoverer=discoverer,
+        summarizer=summarizer, embedder=embedder,
     )
-
-    app.searcher = HybridSearcher(
-        db=app.db,
-        embedder=embedder,
-    )
+    app.searcher = HybridSearcher(db=app.db, embedder=embedder)
 
     app.indexing_queue = IndexingQueue(
-        pipeline=app.pipeline,
-        updates_hub=app.updates_hub,
-        config=settings.queue,
-        db=app.db,
+        pipeline=app.pipeline, updates_hub=app.updates_hub,
+        config=settings.queue, db=app.db,
     )
-    await app.indexing_queue.start()
-
-    app.scheduler = Scheduler(
-        queue=app.indexing_queue,
-        updates_hub=app.updates_hub,
-        config=settings.scheduler,
-    )
-    app.scheduler.start()
-
     app.model_lifecycle = ModelLifecycleManager(
         summarizer=summarizer,
         idle_unload_seconds=settings.summarizer.idle_unload_seconds,
         embedder=embedder,
     )
-    app.model_lifecycle.start()
 
-    app.watcher = Watcher(
-        db=app.db,
-        pipeline=app.pipeline,
-        filter_manager=app.filter_manager,
-        indexing_queue=app.indexing_queue,
-    )
+    logger.info("Phase 1 complete — API is ready")
 
-    # Run startup cleanup to remove excluded files from database
-    logger.info("Running startup cleanup for excluded files")
-    removed_count = await cleanup_excluded_files_on_startup(app.db, app.filter_manager)
-    if removed_count > 0:
-        logger.info("Startup cleanup complete", removed_files=removed_count)
+    # ── Phase 2: Background — load models and start indexing ──
+    async def _deferred_startup():
+        try:
+            # Load embedding model (this is the slow part, ~6s)
+            logger.info("Phase 2: Loading embedding model...")
+            if embedder.preferred_provider in ("local", "lazy_local"):
+                embedder.preferred_provider = "local"
+                embedder._eagerly_initialize_models()
+            logger.info("Embedding model loaded — search is ready")
 
-    await app.watcher.initialize_from_database()
+            # Start indexing services
+            await app.indexing_queue.start()
+            app.scheduler = Scheduler(
+                queue=app.indexing_queue, updates_hub=app.updates_hub,
+                config=settings.scheduler,
+            )
+            app.scheduler.start()
+            app.model_lifecycle.start()
 
-    logger.info("Initialized services")
+            app.watcher = Watcher(
+                db=app.db, pipeline=app.pipeline,
+                filter_manager=app.filter_manager,
+                indexing_queue=app.indexing_queue,
+            )
+
+            logger.info("Running startup cleanup")
+            removed = await cleanup_excluded_files_on_startup(app.db, app.filter_manager)
+            if removed > 0:
+                logger.info("Cleanup complete", removed_files=removed)
+
+            await app.watcher.initialize_from_database()
+            logger.info("Phase 2 complete — indexing is ready")
+        except Exception:
+            logger.exception("Error in deferred startup")
+
+    app.run_task(_deferred_startup())
 
 
 async def cleanup_excluded_files_on_startup(db: Database, filter_manager: FilterConfigManager) -> int:

--- a/packages/cosma-backend/src/cosma_backend/app.py
+++ b/packages/cosma-backend/src/cosma_backend/app.py
@@ -235,50 +235,61 @@ async def cleanup_excluded_files_on_startup(db: Database, filter_manager: Filter
     watched_dirs = await db.get_watched_directories(active_only=True)
     removed_count = 0
 
-    # Step 1: Clean up orphaned files (not under any active watched directory)
+    # Step 1: Clean up orphaned files (not under any active watched directory).
+    # Uses SQL-level DELETE to avoid loading all file rows into Python memory.
     async with db.acquire() as conn:
-        all_files = await conn.fetchall("SELECT id, file_path FROM files")
-
-        for row in all_files:
-            file_path = row["file_path"]
-            is_under_watched = False
-
-            for watched_dir in watched_dirs:
-                watched_path = str(watched_dir.path)
-                if file_path.startswith(watched_path + "/") or file_path == watched_path:
-                    is_under_watched = True
-                    break
-
-            if not is_under_watched:
-                await conn.execute("DELETE FROM files WHERE id = ?", (row["id"],))
-                removed_count += 1
-                logger.info("Removed orphaned file from index (not under any watched directory)",
-                              file_path=file_path)
+        if not watched_dirs:
+            cursor = await conn.execute("SELECT COUNT(*) FROM files")
+            row = await cursor.fetchone()
+            removed_count = row[0] if row else 0
+            if removed_count:
+                await conn.execute("DELETE FROM files")
+        else:
+            # Build a single DELETE that removes files not under any watched dir
+            conditions = " AND ".join(
+                "(file_path NOT LIKE ? || '/' || '%' AND file_path != ?)"
+                for _ in watched_dirs
+            )
+            params: list[str] = []
+            for wd in watched_dirs:
+                wp = str(wd.path)
+                params.extend([wp, wp])
+            cursor = await conn.execute(
+                f"DELETE FROM files WHERE {conditions}", tuple(params)
+            )
+            removed_count = cursor.rowcount
+            if removed_count:
+                logger.info("Removed orphaned files not under any watched directory",
+                            count=removed_count)
 
     if not watched_dirs:
         return removed_count
 
-    # Step 2: Clean up excluded files under watched directories
+    # Step 2: Clean up excluded files under watched directories.
+    # Uses cursor iteration instead of fetchall to keep memory bounded.
     for watched_dir in watched_dirs:
         base_path = watched_dir.path
         config = filter_manager.get_config_for_directory(base_path)
 
-        # Get all files under this directory from database
+        ids_to_delete: list = []
         async with db.acquire() as conn:
-            rows = await conn.fetchall(
-                "SELECT id, file_path FROM files WHERE file_path LIKE ? || '/%' OR file_path = ?",
+            cursor = await conn.execute(
+                "SELECT id, file_path FROM files WHERE file_path LIKE ? || '/' || '%' OR file_path = ?",
                 (str(base_path), str(base_path))
             )
-
+            rows = await cursor.fetchall()
             for row in rows:
                 file_path = Path(row["file_path"])
-
                 if not config.should_include(file_path, base_path):
-                    # File should be excluded, delete it
-                    await conn.execute("DELETE FROM files WHERE id = ?", (row["id"],))
-                    removed_count += 1
-                    logger.info("Removed excluded file from index",
-                                  file_path=str(file_path))
+                    ids_to_delete.append(row["id"])
+
+            # Batch delete collected IDs
+            for file_id in ids_to_delete:
+                await conn.execute("DELETE FROM files WHERE id = ?", (file_id,))
+            removed_count += len(ids_to_delete)
+            if ids_to_delete:
+                logger.info("Removed excluded files under directory",
+                            directory=str(base_path), count=len(ids_to_delete))
 
     return removed_count
 

--- a/packages/cosma-backend/src/cosma_backend/app.py
+++ b/packages/cosma-backend/src/cosma_backend/app.py
@@ -254,11 +254,16 @@ async def cleanup_excluded_files_on_startup(db: Database, filter_manager: Filter
             for wd in watched_dirs:
                 wp = str(wd.path)
                 params.extend([wp, wp])
-            cursor = await conn.execute(
-                f"DELETE FROM files WHERE {conditions}", tuple(params)
+            # Count first, then delete (asqlite Cursor has no rowcount)
+            count_cursor = await conn.execute(
+                f"SELECT COUNT(*) FROM files WHERE {conditions}", tuple(params)
             )
-            removed_count = cursor.rowcount
+            count_row = await count_cursor.fetchone()
+            removed_count = count_row[0] if count_row else 0
             if removed_count:
+                await conn.execute(
+                    f"DELETE FROM files WHERE {conditions}", tuple(params)
+                )
                 logger.info("Removed orphaned files not under any watched directory",
                             count=removed_count)
 

--- a/packages/cosma-backend/src/cosma_backend/app.py
+++ b/packages/cosma-backend/src/cosma_backend/app.py
@@ -49,6 +49,8 @@ load_dotenv()
 
 import os
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+# Limit PyTorch MPS memory usage (set before torch is imported)
+os.environ.setdefault("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.75")
 
 configure_logging()
 logger = get_logger(__name__)
@@ -167,6 +169,36 @@ async def initialize_services():
                   config_path=str(global_config.config_path))
 
     settings = app.settings_manager.settings
+
+    # Apply GPU memory cap from settings.
+    #
+    # IMPORTANT: the cap affects different backends differently:
+    #   * PyTorch / MPS (embedder, local whisper) — honors
+    #     PYTORCH_MPS_HIGH_WATERMARK_RATIO directly.
+    #   * llama.cpp (summarizer via llama-cpp-python) — uses its own Metal
+    #     backend. Memory usage is controlled by `summarizer.llamacpp.n_gpu_layers`
+    #     (negative = all layers on GPU, positive = N layers only). Metal
+    #     respects system memory pressure automatically.
+    #   * Ollama — runs as a separate process. Configure Ollama itself via
+    #     OLLAMA_NUM_GPU / OLLAMA_KEEP_ALIVE env vars before launching it;
+    #     this setting has no direct effect on an already-running Ollama server.
+    gpu_cap = settings.queue.gpu_memory_cap
+    if not (0.0 < gpu_cap <= 1.0):
+        logger.warning("Invalid gpu_memory_cap, falling back to 0.75",
+                      configured=gpu_cap)
+        gpu_cap = 0.75
+    os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = str(gpu_cap)
+
+    # Hint for any Ollama instance spawned in this environment
+    os.environ.setdefault("OLLAMA_KEEP_ALIVE", "5m")
+
+    logger.info(
+        "GPU memory cap applied",
+        gpu_cap=f"{gpu_cap:.0%}",
+        affects="torch (embedder, local whisper)",
+        note="llama.cpp uses n_gpu_layers; Ollama uses its own env config",
+    )
+
     discoverer = Discoverer()
     parser = FileParser(config=settings.parser)
     summarizer = AutoSummarizer(config=settings.summarizer)
@@ -228,7 +260,7 @@ async def initialize_services():
         except Exception:
             logger.exception("Error in deferred startup")
 
-    app.run_task(_deferred_startup())
+    asyncio.ensure_future(_deferred_startup())
 
 
 async def cleanup_excluded_files_on_startup(db: Database, filter_manager: FilterConfigManager) -> int:
@@ -310,12 +342,48 @@ async def cleanup_excluded_files_on_startup(db: Database, filter_manager: Filter
 
 @app.after_serving
 async def handle_shutdown():
-    logger.info("Stopping model lifecycle manager, scheduler, and indexing queue")
-    await app.model_lifecycle.stop()
-    await app.scheduler.stop()
-    await app.indexing_queue.stop()
-    logger.info("Closing DB")
-    await app.db.close()
+    logger.info("Shutdown: stopping lifecycle manager, scheduler, and indexing queue")
+    try:
+        await app.model_lifecycle.stop()
+    except Exception:
+        logger.exception("Error stopping model lifecycle manager")
+    try:
+        await app.scheduler.stop()
+    except Exception:
+        logger.exception("Error stopping scheduler")
+    try:
+        await app.indexing_queue.stop()
+    except Exception:
+        logger.exception("Error stopping indexing queue")
+
+    # Unload summarizer models — this is important for Ollama, which runs in a
+    # separate process and keeps the model pinned in GPU until explicitly told
+    # to release (via a request with keep_alive=0). Without this call, Ollama
+    # can hold 100% of GPU memory even after the backend quits.
+    logger.info("Shutdown: unloading summarizer models")
+    try:
+        summarizer = getattr(app.pipeline, "summarizer", None)
+        if summarizer is not None and hasattr(summarizer, "unload_models"):
+            await asyncio.wait_for(summarizer.unload_models(), timeout=5.0)
+    except asyncio.TimeoutError:
+        logger.warning("Summarizer unload timed out after 5s")
+    except Exception:
+        logger.exception("Error unloading summarizer models")
+
+    # Unload Whisper if it was loaded
+    try:
+        from cosma_backend.parser.media import unload_whisper_model
+        unload_whisper_model()
+    except Exception:
+        logger.exception("Error unloading whisper model")
+
+    logger.info("Shutdown: closing DB")
+    try:
+        await app.db.close()
+    except Exception:
+        logger.exception("Error closing DB")
+
+    logger.info("Shutdown complete")
     
 
 @app.before_request

--- a/packages/cosma-backend/src/cosma_backend/app.py
+++ b/packages/cosma-backend/src/cosma_backend/app.py
@@ -226,41 +226,80 @@ async def initialize_services():
     logger.info("Phase 1 complete — API is ready")
 
     # ── Phase 2: Background — load models and start indexing ──
-    async def _deferred_startup():
+    # Start indexing services immediately (non-blocking async)
+    await app.indexing_queue.start()
+    app.scheduler = Scheduler(
+        queue=app.indexing_queue, updates_hub=app.updates_hub,
+        config=settings.scheduler,
+    )
+    app.indexing_queue.set_pre_task_hook(app.scheduler.evaluate_and_apply)
+    app.scheduler.start()
+    app.model_lifecycle.start()
+
+    app.watcher = Watcher(
+        db=app.db, pipeline=app.pipeline,
+        filter_manager=app.filter_manager,
+        indexing_queue=app.indexing_queue,
+    )
+
+    # Progress tracking for Phase 2 (0.0 → 1.0)
+    app._deferred_init_progress: float = 0.0
+    app._model_loading_done = asyncio.Event()
+
+    async def _model_loading_progress_updater():
+        """Smoothly increment progress from 10% → 78% over ~12 s while
+        the embedding model loads on a background thread."""
+        progress = 0.10
+        while not app._model_loading_done.is_set():
+            remaining = 0.78 - progress
+            if remaining > 0.01:
+                progress += remaining * 0.06
+                app._deferred_init_progress = progress
+            try:
+                await asyncio.wait_for(
+                    app._model_loading_done.wait(), timeout=0.3,
+                )
+                break
+            except asyncio.TimeoutError:
+                pass
+
+    async def _deferred_heavy_init():
+        """Load embedding model in a thread so it doesn't block the event loop.
+
+        This lets Uvicorn start accepting connections immediately after Phase 1
+        instead of waiting ~8s for the SentenceTransformer model to load.
+        Cancellation-safe: if SIGTERM arrives mid-load, the task is cancelled.
+        """
         try:
-            # Load embedding model (this is the slow part, ~6s)
+            app._deferred_init_progress = 0.05
             logger.info("Phase 2: Loading embedding model...")
             if embedder.preferred_provider in ("local", "lazy_local"):
                 embedder.preferred_provider = "local"
-                embedder._eagerly_initialize_models()
+                app._deferred_init_progress = 0.10
+                progress_task = asyncio.ensure_future(
+                    _model_loading_progress_updater(),
+                )
+                await asyncio.to_thread(embedder._eagerly_initialize_models)
+                app._model_loading_done.set()
+                await progress_task
+            app._deferred_init_progress = 0.80
             logger.info("Embedding model loaded — search is ready")
-
-            # Start indexing services
-            await app.indexing_queue.start()
-            app.scheduler = Scheduler(
-                queue=app.indexing_queue, updates_hub=app.updates_hub,
-                config=settings.scheduler,
-            )
-            app.scheduler.start()
-            app.model_lifecycle.start()
-
-            app.watcher = Watcher(
-                db=app.db, pipeline=app.pipeline,
-                filter_manager=app.filter_manager,
-                indexing_queue=app.indexing_queue,
-            )
 
             logger.info("Running startup cleanup")
             removed = await cleanup_excluded_files_on_startup(app.db, app.filter_manager)
             if removed > 0:
                 logger.info("Cleanup complete", removed_files=removed)
+            app._deferred_init_progress = 0.90
 
             await app.watcher.initialize_from_database()
+            app._deferred_init_progress = 1.0
             logger.info("Phase 2 complete — indexing is ready")
+        except asyncio.CancelledError:
+            logger.info("Phase 2 cancelled (shutdown in progress)")
         except Exception:
             logger.exception("Error in deferred startup")
 
-    asyncio.ensure_future(_deferred_startup())
+    app._deferred_init_task = asyncio.ensure_future(_deferred_heavy_init())
 
 
 async def cleanup_excluded_files_on_startup(db: Database, filter_manager: FilterConfigManager) -> int:
@@ -342,6 +381,17 @@ async def cleanup_excluded_files_on_startup(db: Database, filter_manager: Filter
 
 @app.after_serving
 async def handle_shutdown():
+    # Cancel Phase 2 if it's still running (e.g. model loading in thread).
+    # This prevents the shutdown from waiting on a slow model download.
+    deferred = getattr(app, "_deferred_init_task", None)
+    if deferred and not deferred.done():
+        logger.info("Shutdown: cancelling deferred startup")
+        deferred.cancel()
+        try:
+            await deferred
+        except (asyncio.CancelledError, Exception):
+            pass
+
     logger.info("Shutdown: stopping lifecycle manager, scheduler, and indexing queue")
     try:
         await app.model_lifecycle.stop()
@@ -364,9 +414,9 @@ async def handle_shutdown():
     try:
         summarizer = getattr(app.pipeline, "summarizer", None)
         if summarizer is not None and hasattr(summarizer, "unload_models"):
-            await asyncio.wait_for(summarizer.unload_models(), timeout=5.0)
+            await asyncio.wait_for(summarizer.unload_models(), timeout=3.0)
     except asyncio.TimeoutError:
-        logger.warning("Summarizer unload timed out after 5s")
+        logger.warning("Summarizer unload timed out after 3s")
     except Exception:
         logger.exception("Error unloading summarizer models")
 

--- a/packages/cosma-backend/src/cosma_backend/db/database.py
+++ b/packages/cosma-backend/src/cosma_backend/db/database.py
@@ -198,7 +198,7 @@ class Database:
                 # Insert new keywords
                 for keyword in file_data.keywords:
                     await conn.execute(
-                        "INSERT INTO file_keywords (file_id, keyword) VALUES (?, ?)",
+                        "INSERT OR IGNORE INTO file_keywords (file_id, keyword) VALUES (?, ?)",
                         (file_data.id, keyword)
                     )
             

--- a/packages/cosma-backend/src/cosma_backend/db/database.py
+++ b/packages/cosma-backend/src/cosma_backend/db/database.py
@@ -495,6 +495,16 @@ class Database:
             logger.info("Retrieved watched directories", count=len(directories), active_only=active_only)
             return directories
 
+    async def count_files_in_directory(self, directory_path: str) -> int:
+        """Count indexed files under a watched directory path."""
+        async with self.acquire() as conn:
+            cursor = await conn.execute(
+                "SELECT COUNT(*) FROM files WHERE file_path LIKE ? || '/' || '%' OR file_path = ?",
+                (directory_path, directory_path),
+            )
+            row = await cursor.fetchone()
+            return row[0] if row else 0
+
     async def delete_watched_directory(self, job_id: int) -> WatchedDirectory | None:
         """
         Delete a watched directory by ID and clean up all associated files.

--- a/packages/cosma-backend/src/cosma_backend/embedder/auto.py
+++ b/packages/cosma-backend/src/cosma_backend/embedder/auto.py
@@ -51,7 +51,9 @@ class AutoEmbedder:
                     preferred_provider=self.preferred_provider)
 
         # Eagerly initialize models based on preferred provider
-        self._eagerly_initialize_models()
+        # "lazy_local" skips eager loading — model will load on first use
+        if self.preferred_provider != "lazy_local":
+            self._eagerly_initialize_models()
 
     def _eagerly_initialize_models(self) -> None:
         """Initialize embedding models based on provider preference - eager for local, lazy for online."""

--- a/packages/cosma-backend/src/cosma_backend/embedder/providers.py
+++ b/packages/cosma-backend/src/cosma_backend/embedder/providers.py
@@ -184,8 +184,9 @@ class LocalEmbedder(BaseEmbedder):
         from sentence_transformers import SentenceTransformer
         logger.info("Loading local embedding model on first use",
                      model=self.model_name, dimensions=self.configured_dimensions)
-        self.model = SentenceTransformer(self.model_name)
-        logger.info("Local embedding model loaded", model=self.model_name)
+        # Force CPU to avoid MPS sdpa assertion crash on Apple Silicon
+        self.model = SentenceTransformer(self.model_name, device="cpu")
+        logger.info("Local embedding model loaded", model=self.model_name, device="cpu")
 
     def unload_model(self) -> None:
         """Unload the model to free memory."""

--- a/packages/cosma-backend/src/cosma_backend/model_lifecycle.py
+++ b/packages/cosma-backend/src/cosma_backend/model_lifecycle.py
@@ -7,9 +7,10 @@ reduce memory usage when models aren't actively being used.
 
 Monitored models:
 - Summarizer (Ollama, LlamaCpp, or online)
+- Embedder (local SentenceTransformer)
 - Whisper (audio transcription)
 
-The embedder is kept loaded permanently for instant search.
+All models are lazily reloaded on next use after being unloaded.
 
 Each model tracks its last_used_at timestamp. When idle time
 exceeds the threshold, the model is unloaded to free resources.
@@ -100,7 +101,18 @@ class ModelLifecycleManager:
                             )
                             await self._summarizer.unload_models()
 
-                # Embedder stays loaded permanently for instant search.
+                # Check embedder idle time (lazy-reloads on next use)
+                if self._embedder is not None and self._embedder.is_model_loaded():
+                    last_used = self._embedder.last_used_at
+                    if last_used > 0:
+                        idle_time = now - last_used
+                        if idle_time > self._idle_unload_seconds:
+                            logger.info(
+                                "Embedder idle, unloading",
+                                idle_seconds=round(idle_time, 1),
+                                threshold=self._idle_unload_seconds,
+                            )
+                            await self._embedder.unload_models()
 
                 # Check whisper model idle time
                 from cosma_backend.parser.media import (
@@ -116,7 +128,7 @@ class ModelLifecycleManager:
                             idle_seconds=round(whisper_idle, 1),
                             threshold=self._idle_unload_seconds,
                         )
-                        unload_whisper_model()
+                        await asyncio.to_thread(unload_whisper_model)
 
                 await asyncio.sleep(CHECK_INTERVAL_SECONDS)
             except asyncio.CancelledError:

--- a/packages/cosma-backend/src/cosma_backend/model_lifecycle.py
+++ b/packages/cosma-backend/src/cosma_backend/model_lifecycle.py
@@ -7,10 +7,9 @@ reduce memory usage when models aren't actively being used.
 
 Monitored models:
 - Summarizer (Ollama, LlamaCpp, or online)
-- Embedder (local SentenceTransformer)
 - Whisper (audio transcription)
 
-All models are lazily reloaded on next use after being unloaded.
+The embedder is kept loaded permanently for instant search.
 
 Each model tracks its last_used_at timestamp. When idle time
 exceeds the threshold, the model is unloaded to free resources.
@@ -101,18 +100,7 @@ class ModelLifecycleManager:
                             )
                             await self._summarizer.unload_models()
 
-                # Check embedder idle time (lazy-reloads on next use)
-                if self._embedder is not None and self._embedder.is_model_loaded():
-                    last_used = self._embedder.last_used_at
-                    if last_used > 0:
-                        idle_time = now - last_used
-                        if idle_time > self._idle_unload_seconds:
-                            logger.info(
-                                "Embedder idle, unloading",
-                                idle_seconds=round(idle_time, 1),
-                                threshold=self._idle_unload_seconds,
-                            )
-                            await self._embedder.unload_models()
+                # Embedder stays loaded permanently for instant search.
 
                 # Check whisper model idle time
                 from cosma_backend.parser.media import (

--- a/packages/cosma-backend/src/cosma_backend/models/file.py
+++ b/packages/cosma-backend/src/cosma_backend/models/file.py
@@ -127,8 +127,13 @@ class File:
                 logger.warning(f"Failed to parse timestamp: {value}")
                 return None
         
-        # Parse status from string to enum
-        status = ProcessingStatus[row["status"]] if row["status"] else ProcessingStatus.DISCOVERED
+        # Parse status from string to enum (with fallback for corrupted data)
+        try:
+            status = ProcessingStatus[row["status"]] if row["status"] else ProcessingStatus.DISCOVERED
+        except KeyError:
+            logger.warning("Invalid processing status in database, defaulting to DISCOVERED",
+                          status=row["status"], file_path=row.get("file_path"))
+            status = ProcessingStatus.DISCOVERED
         
         # Parse timestamps (they're stored as UNIX timestamps in the database)
         created = parse_timestamp(row["created"])

--- a/packages/cosma-backend/src/cosma_backend/models/file.py
+++ b/packages/cosma-backend/src/cosma_backend/models/file.py
@@ -68,6 +68,11 @@ class File:
     # Meta
     status: ProcessingStatus = ProcessingStatus.DISCOVERED
     processing_error: Optional[str] = None
+    # DB bookkeeping: time the row was last written (set automatically by
+    # `upsert_file` via strftime('%s','now')). This is the correct value to
+    # show as "processed at" in the Recent/Failed lists — `modified` is the
+    # filesystem mtime and can be years old.
+    updated_at: Optional[datetime] = None
 
     # Transient data (not persisted to DB)
     # Used to pass video frames to the summarizer for vision analysis
@@ -142,6 +147,7 @@ class File:
         parsed_at = parse_timestamp(get_value("parsed_at"))
         summarized_at = parse_timestamp(get_value("summarized_at"))
         embedded_at = parse_timestamp(get_value("embedded_at"))
+        updated_at = parse_timestamp(get_value("updated_at"))
         
         # Parse keywords if present (stored as comma or || separated string)
         keywords = None
@@ -170,6 +176,7 @@ class File:
             embedded_at=embedded_at,
             status=status,
             processing_error=get_value("processing_error"),
+            updated_at=updated_at,
         )
     
     def to_response(self) -> "FileResponse":

--- a/packages/cosma-backend/src/cosma_backend/parser/media.py
+++ b/packages/cosma-backend/src/cosma_backend/parser/media.py
@@ -60,6 +60,10 @@ async def extract_audio_transcript(path: Path, config: ParserConfig | None = Non
     """
     Extract transcript from audio file using configurable backends.
 
+    Includes automatic fallback: if the preferred backend is unavailable
+    (e.g., local openai-whisper not installed), tries the other available
+    backend instead of silently failing.
+
     Args:
         path: Path to audio file
         config: ParserConfig instance
@@ -71,35 +75,74 @@ async def extract_audio_transcript(path: Path, config: ParserConfig | None = Non
     from cosma_backend.settings import ParserConfig as _ParserConfig
     cfg = config or _ParserConfig()
     provider = backend or cfg.whisper.provider
-    
+
     # Map provider names to backend names
     backend_map = {"online": "openai", "local": "local", "openai": "openai"}
-    backend = backend_map.get(provider, "openai")
-    
+    preferred = backend_map.get(provider, "openai")
+
     if not path.exists():
         logger.warning("Audio file not found", path=str(path))
         return None
-        
-    logger.info("Extracting audio transcript", 
-               path=str(path), 
-               backend=backend,
+
+    # Build fallback order: preferred first, then the other backend as fallback
+    backends_to_try: list[str] = [preferred]
+    if preferred == "local":
+        backends_to_try.append("openai")
+    elif preferred == "openai":
+        backends_to_try.append("local")
+
+    logger.info("Extracting audio transcript",
+               path=str(path),
+               preferred=preferred,
                size=path.stat().st_size)
-    
-    try:
-        if backend == "openai":
-            return await _transcribe_with_openai(path)
-        elif backend == "local":
-            return await _transcribe_with_local_whisper(path)
-        else:
-            logger.error("Unknown Whisper backend", backend=backend)
-            return None
-            
-    except Exception as e:
-        logger.exception("Audio transcription failed", 
-                        path=str(path), 
-                        backend=backend,
-                        error=str(e))
-        return None
+
+    last_error: str | None = None
+    for attempt_backend in backends_to_try:
+        try:
+            if attempt_backend == "openai":
+                # Skip openai if no API key configured — save time and give a
+                # clearer error path.
+                if not os.getenv("OPENAI_API_KEY"):
+                    last_error = "OpenAI API key not set (OPENAI_API_KEY)"
+                    logger.info("Skipping OpenAI transcription",
+                               path=str(path), reason=last_error)
+                    continue
+                result = await _transcribe_with_openai(path)
+            elif attempt_backend == "local":
+                # Quick pre-check: is the local whisper library importable?
+                import importlib.util
+                if importlib.util.find_spec("whisper") is None and not await _check_whisper_cpp_available():
+                    last_error = "Neither openai-whisper nor whisper.cpp is installed"
+                    logger.warning("Local whisper unavailable, will try fallback",
+                                   path=str(path), reason=last_error)
+                    continue
+                result = await _transcribe_with_local_whisper(path)
+            else:
+                logger.error("Unknown Whisper backend", backend=attempt_backend)
+                continue
+
+            if result:
+                if attempt_backend != preferred:
+                    logger.info("Fell back to alternate backend successfully",
+                               path=str(path),
+                               preferred=preferred,
+                               used=attempt_backend)
+                return result
+
+            # None returned but no exception — treat as soft failure, try next
+            last_error = f"{attempt_backend} backend returned no transcript"
+
+        except Exception as e:
+            last_error = f"{attempt_backend} raised: {e}"
+            logger.exception("Audio transcription backend failed, trying fallback",
+                            path=str(path),
+                            backend=attempt_backend,
+                            error=str(e))
+
+    logger.warning("All audio transcription backends failed",
+                   path=str(path),
+                   last_error=last_error)
+    return None
 
 
 from dataclasses import dataclass, field
@@ -201,6 +244,7 @@ async def _extract_video_frames(path: Path, num_frames: int = DEFAULT_NUM_FRAMES
         List of JPEG-encoded frame bytes
     """
     frames: list[bytes] = []
+    MAX_TOTAL_FRAME_SIZE = 50 * 1024 * 1024  # 50MB total limit for all frames
 
     try:
         # First, get video duration
@@ -224,11 +268,18 @@ async def _extract_video_frames(path: Path, num_frames: int = DEFAULT_NUM_FRAMES
                 for i in range(num_frames)
             ]
 
-        # Extract each frame
+        # Extract each frame with total size tracking
+        total_frame_size = 0
         for i, ts in enumerate(timestamps):
             frame_data = await _extract_single_frame(path, ts)
             if frame_data:
+                if total_frame_size + len(frame_data) > MAX_TOTAL_FRAME_SIZE:
+                    logger.warning("Frame extraction size limit reached",
+                                  frames_extracted=len(frames),
+                                  total_size=total_frame_size)
+                    break
                 frames.append(frame_data)
+                total_frame_size += len(frame_data)
                 logger.debug("Extracted frame", index=i, timestamp=ts)
 
         logger.info("Frames extracted from video",
@@ -659,7 +710,11 @@ async def _transcribe_with_whisper_python(audio_path: Path) -> str | None:
         return None
 
     except ImportError:
-        logger.error("Whisper library not installed - install with: pip install openai-whisper")
+        logger.warning(
+            "openai-whisper package not installed — "
+            "install with `uv pip install openai-whisper` or configure "
+            "Whisper provider to 'online' in Settings"
+        )
         return None
     except Exception as e:
         logger.exception("Whisper Python error", error=str(e))

--- a/packages/cosma-backend/src/cosma_backend/parser/parser.py
+++ b/packages/cosma-backend/src/cosma_backend/parser/parser.py
@@ -250,7 +250,10 @@ class FileParser:
             error_msg = f"Failed to parse file: {e!s}"
             logger.exception(error_msg, file_path=str(path), error=str(e))
 
-            raise e
+            # Ensure file has a consistent failed state before re-raising
+            file.status = ProcessingStatus.FAILED
+            file.processing_error = error_msg
+            raise
 
     async def _try_spotlight_extraction(self, path: Path) -> str | None:
         """
@@ -352,9 +355,13 @@ class FileParser:
         """
         try:
             logger.debug("Trying MarkItDown extraction", path=str(path))
-            
-            result = await asyncio.to_thread(self.markitdown.convert, str(path))
-            
+
+            # Timeout prevents hangs on malformed/malicious files
+            result = await asyncio.wait_for(
+                asyncio.to_thread(self.markitdown.convert, str(path)),
+                timeout=120,  # 2 minute max per file
+            )
+
             if result and result.text_content:
                 content = result.text_content.strip()
                 if len(content) > 0:
@@ -366,9 +373,12 @@ class FileParser:
             logger.debug("MarkItDown extraction returned empty content", path=str(path))
             return None
             
+        except asyncio.TimeoutError:
+            logger.warning("MarkItDown extraction timed out", path=str(path))
+            return None
         except Exception as e:
-            logger.debug("MarkItDown extraction failed", 
-                            path=str(path), 
+            logger.debug("MarkItDown extraction failed",
+                            path=str(path),
                             error=str(e))
             return None
 

--- a/packages/cosma-backend/src/cosma_backend/parser/spotlight.py
+++ b/packages/cosma-backend/src/cosma_backend/parser/spotlight.py
@@ -73,7 +73,14 @@ async def spotlight_to_text(path: Path, config: ParserConfig | None = None) -> s
             return None
             
         output = stdout.decode().strip()
-        
+
+        # Cap output size to prevent memory exhaustion from huge metadata
+        MAX_SPOTLIGHT_OUTPUT = 1024 * 1024  # 1MB
+        if len(output) > MAX_SPOTLIGHT_OUTPUT:
+            logger.warning("Spotlight output too large, truncating",
+                          path=str(path), size=len(output))
+            output = output[:MAX_SPOTLIGHT_OUTPUT]
+
         # Parse mdls output format: kMDItemTextContent = "content here"
         if "= " not in output:
             logger.debug("No text content found in Spotlight", path=str(path))

--- a/packages/cosma-backend/src/cosma_backend/pipeline/pipeline.py
+++ b/packages/cosma-backend/src/cosma_backend/pipeline/pipeline.py
@@ -109,16 +109,17 @@ class Pipeline:
                 await self.db.update_file_timestamp(file.file_path)
 
                 # Check if file needs processing
-                if await self._should_skip_file(file):
+                should_skip, saved_file = await self._should_skip_file(file)
+                if should_skip:
                     logger.info("Skipping processing file", file=file)
                     self._publish_update(Update.file_skipped(
-                        file.file_path, 
-                        file.filename, 
+                        file.file_path,
+                        file.filename,
                         reason="already processed"
                     ))
                     # result.skipped += 1
                     continue
-                
+
                 # Process the file through the pipeline
                 await self.process_file(file)
 
@@ -168,7 +169,8 @@ class Pipeline:
                 # Touch the timestamp so stale-file cleanup knows this file still exists
                 await self.db.update_file_timestamp(file.file_path)
 
-                if await self._should_skip_file(file):
+                should_skip, _saved = await self._should_skip_file(file)
+                if should_skip:
                     self._publish_update(Update.file_skipped(
                         file.file_path, file.filename, reason="already processed"
                     ))
@@ -283,37 +285,43 @@ class Pipeline:
         """Check if a file is supported for processing"""
         return self.parser.is_supported(file)
     
-    async def _should_skip_file(self, file: File) -> bool:
-        """Check if file should be skipped based on DB state."""
+    async def _should_skip_file(self, file: File) -> tuple[bool, File | None]:
+        """Check if file should be skipped based on DB state.
+
+        Returns (should_skip, saved_file) so callers can reuse the DB record.
+        """
         if not await self.is_supported(file):
             logger.debug("Skipping unsupported file", file=file.file_path)
-            return True
+            return True, None
 
         saved_file = await self.db.get_file_by_path(file.file_path)
 
         # File not in DB or not yet fully processed - don't skip
         if not saved_file or saved_file.status not in (ProcessingStatus.COMPLETE, ProcessingStatus.FAILED):
             logger.debug("File needs processing", file=file.file_path, status=saved_file.status if saved_file else "not in DB")
-            return False
-            
+            return False, saved_file
+
         saved_modified = saved_file.modified.replace(microsecond=0)
         current_modified = file.modified.replace(microsecond=0)
-        
+
         logger.info("Should skip", file=file, saved_modified=saved_modified, current_modified=current_modified)
-            
-        return saved_modified == current_modified
 
+        return saved_modified == current_modified, saved_file
 
+    async def _has_file_changed(self, file: File, saved_file: File | None = None) -> bool:
+        """Check if file content has changed based on hash.
 
-    async def _has_file_changed(self, file: File) -> bool:
-        """Check if file has been changed based on hash."""
-        saved_file = await self.db.get_file_by_path(file.file_path)
-        
+        Accepts an optional pre-fetched ``saved_file`` to avoid a redundant
+        DB query when the caller already has it.
+        """
+        if saved_file is None:
+            saved_file = await self.db.get_file_by_path(file.file_path)
+
         logger.info("Saved file", saved_file=saved_file, status=saved_file.status if saved_file else "N/A")
-        
+
         if not saved_file or saved_file.status is not ProcessingStatus.COMPLETE:
             return True
-            
+
         return saved_file.content_hash != file.content_hash
     
     def _apply_fallback_indexing(self, file: File) -> None:

--- a/packages/cosma-backend/src/cosma_backend/pipeline/pipeline.py
+++ b/packages/cosma-backend/src/cosma_backend/pipeline/pipeline.py
@@ -248,13 +248,18 @@ class Pipeline:
             await self._save_to_db(file)
             self._publish_update(Update.file_summarized(file.file_path, file.filename))
             
-            # Stage 3: Embed (if embedder is available)
-            self._publish_update(Update.file_embedding(file.file_path, file.filename))
-            await self.embedder.embed(file)
-            # embeddings need special care when saving
-            await self._save_embeddings(file)
-            self._publish_update(Update.file_embedded(file.file_path, file.filename))
-            
+            # Stage 3: Embed — non-fatal; file is still FTS-searchable without embeddings
+            try:
+                self._publish_update(Update.file_embedding(file.file_path, file.filename))
+                await self.embedder.embed(file)
+                await self._save_embeddings(file)
+                self._publish_update(Update.file_embedded(file.file_path, file.filename))
+            except Exception as embed_err:
+                logger.warning("Embedding failed, file saved without embeddings",
+                               file=file.file_path, error=str(embed_err))
+                # File is still COMPLETE for FTS — just missing semantic search
+                file.status = ProcessingStatus.COMPLETE
+
             # Mark as complete
             self._publish_update(Update.file_complete(file.file_path, file.filename))
             

--- a/packages/cosma-backend/src/cosma_backend/queue/indexing_queue.py
+++ b/packages/cosma-backend/src/cosma_backend/queue/indexing_queue.py
@@ -13,7 +13,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import Any, Awaitable, Callable, TYPE_CHECKING, Optional
 
 from cosma_backend.db.errors import DatabaseClosingError
 from cosma_backend.logging import get_logger
@@ -104,6 +104,19 @@ class IndexingQueue:
 
         self._processing_task: Optional[asyncio.Task] = None
         self._semaphore = asyncio.Semaphore(self._config.max_concurrency)
+
+        # Optional hook invoked right before each batch of ready items is
+        # dispatched. The scheduler installs this so rule evaluation happens
+        # at task boundaries (not mid-task). The hook may set
+        # ``_scheduler_paused`` via queue.scheduler_pause() — the loop will
+        # then wait instead of picking up new work.
+        self._pre_task_hook: Optional[Callable[[], Awaitable[Any]]] = None
+
+    def set_pre_task_hook(self, hook: Optional[Callable[[], Awaitable[Any]]]) -> None:
+        """Install a callback invoked once per processing cycle, right
+        before ready items are picked. Used by the scheduler to evaluate
+        rules between tasks without a fixed polling interval."""
+        self._pre_task_hook = hook
 
     # ------------------------------------------------------------------
     # Public properties
@@ -419,6 +432,27 @@ class IndexingQueue:
                             item.status = QueueItemStatus.WAITING
                             items_to_persist.append(item)
 
+                    has_waiting = any(
+                        i.status == QueueItemStatus.WAITING
+                        for i in self._items.values()
+                    )
+
+                # Task-boundary scheduler check: evaluate rules right before
+                # we promote WAITING items to PROCESSING. If the hook flips
+                # is_paused, we loop back and wait without starting new work.
+                # This is the sole "should we run now?" check — there is no
+                # fixed polling interval for GPU/CPU/memory rules, so a
+                # single file's inference cannot get interrupted mid-way.
+                if has_waiting and self._pre_task_hook is not None:
+                    try:
+                        await self._pre_task_hook()
+                    except Exception:
+                        logger.exception("pre_task_hook raised — proceeding anyway")
+                    if self.is_paused:
+                        await asyncio.sleep(1)
+                        continue
+
+                async with self._lock:
                     ready_items = [
                         i for i in self._items.values()
                         if i.status == QueueItemStatus.WAITING

--- a/packages/cosma-backend/src/cosma_backend/queue/indexing_queue.py
+++ b/packages/cosma-backend/src/cosma_backend/queue/indexing_queue.py
@@ -576,7 +576,12 @@ class IndexingQueue:
         try:
             rows = await self._db.get_queue_items()
             for row in rows:
-                action = QueueAction(row["action"])
+                try:
+                    action = QueueAction(row["action"])
+                except ValueError:
+                    logger.error("Invalid queue action type, skipping item",
+                                action=row["action"], item_id=row["id"])
+                    continue
                 # Restore PROCESSING items as WAITING so they get re-processed.
                 # Also map legacy "ready" values to WAITING.
                 raw_status = row["status"]

--- a/packages/cosma-backend/src/cosma_backend/queue/indexing_queue.py
+++ b/packages/cosma-backend/src/cosma_backend/queue/indexing_queue.py
@@ -204,6 +204,8 @@ class IndexingQueue:
         dest_key = str(Path(dest_path).resolve()) if dest_path else None
         now = time.time()
 
+        item_to_persist: Optional[QueueItem] = None
+
         async with self._lock:
             existing = self._items.get(key)
 
@@ -248,25 +250,24 @@ class IndexingQueue:
                         self._publish(Update.create(
                             UpdateOpcode.QUEUE_ITEM_UPDATED, **existing.to_dict()
                         ))
-                        await self._save_item(existing)
+                        item_to_persist = existing
                         logger.info("Queue item fast-tracked to DELETE", file_path=key)
-                        return existing
 
-                    # Otherwise reset the cooldown timer
-                    existing.action = action
-                    existing.cooldown_expires_at = now + cooldown
-                    existing.dest_path = dest_key if dest_key else existing.dest_path
-                    # Update dest mapping
-                    if action == QueueAction.MOVE and existing.dest_path:
-                        self._dest_to_src[existing.dest_path] = key
-                    self._publish(Update.create(
-                        UpdateOpcode.QUEUE_ITEM_UPDATED, **existing.to_dict()
-                    ))
-                    await self._save_item(existing)
-                    logger.info("Queue item cooldown reset", file_path=key)
-                    return existing
+                    else:
+                        # Otherwise reset the cooldown timer
+                        existing.action = action
+                        existing.cooldown_expires_at = now + cooldown
+                        existing.dest_path = dest_key if dest_key else existing.dest_path
+                        # Update dest mapping
+                        if action == QueueAction.MOVE and existing.dest_path:
+                            self._dest_to_src[existing.dest_path] = key
+                        self._publish(Update.create(
+                            UpdateOpcode.QUEUE_ITEM_UPDATED, **existing.to_dict()
+                        ))
+                        item_to_persist = existing
+                        logger.info("Queue item cooldown reset", file_path=key)
 
-                if existing.status == QueueItemStatus.WAITING:
+                elif existing.status == QueueItemStatus.WAITING:
                     # Item is ready but hasn't been dispatched yet; reset it
                     # back to COOLING_DOWN so the new event is debounced.
                     if existing.action == QueueAction.MOVE and existing.dest_path:
@@ -280,33 +281,45 @@ class IndexingQueue:
                     self._publish(Update.create(
                         UpdateOpcode.QUEUE_ITEM_UPDATED, **existing.to_dict()
                     ))
-                    await self._save_item(existing)
+                    item_to_persist = existing
                     logger.info("Queue item reset from WAITING to cooldown",
                                 file_path=key, action=action.value)
-                    return existing
 
-            # New item
-            item = QueueItem(
-                id=str(uuid.uuid4()),
-                file_path=key,
-                action=action,
-                status=QueueItemStatus.COOLING_DOWN,
-                enqueued_at=now,
-                cooldown_expires_at=now + cooldown,
-                dest_path=dest_key,
-            )
-            self._items[key] = item
-            if action == QueueAction.MOVE and dest_key:
-                self._dest_to_src[dest_key] = key
-            self._publish(Update.create(
-                UpdateOpcode.QUEUE_ITEM_ADDED, **item.to_dict()
-            ))
-            await self._save_item(item)
-            logger.info("Item enqueued", file_path=key, action=action.value)
-            return item
+            if item_to_persist is None and existing is not None:
+                # Handled above (PROCESSING stash) — already returned
+                pass
+            elif item_to_persist is not None:
+                # Existing item was updated; will persist below
+                pass
+            else:
+                # New item
+                item = QueueItem(
+                    id=str(uuid.uuid4()),
+                    file_path=key,
+                    action=action,
+                    status=QueueItemStatus.COOLING_DOWN,
+                    enqueued_at=now,
+                    cooldown_expires_at=now + cooldown,
+                    dest_path=dest_key,
+                )
+                self._items[key] = item
+                if action == QueueAction.MOVE and dest_key:
+                    self._dest_to_src[dest_key] = key
+                self._publish(Update.create(
+                    UpdateOpcode.QUEUE_ITEM_ADDED, **item.to_dict()
+                ))
+                item_to_persist = item
+                logger.info("Item enqueued", file_path=key, action=action.value)
+
+        # Persist outside the lock to avoid blocking concurrent operations.
+        if item_to_persist is not None:
+            await self._save_item(item_to_persist)
+
+        return item_to_persist if item_to_persist is not None else existing
 
     async def remove_item(self, item_id: str) -> bool:
         """Remove an item by its ID. Returns True if found and removed."""
+        removed_key: Optional[str] = None
         async with self._lock:
             for key, item in self._items.items():
                 if item.id == item_id:
@@ -315,9 +328,12 @@ class IndexingQueue:
                     self._publish(Update.create(
                         UpdateOpcode.QUEUE_ITEM_REMOVED, **item.to_dict()
                     ))
-                    await self._delete_item_from_db(item_id)
-                    logger.info("Queue item removed", item_id=item_id, file_path=key)
-                    return True
+                    removed_key = key
+                    break
+        if removed_key is not None:
+            await self._delete_item_from_db(item_id)
+            logger.info("Queue item removed", item_id=item_id, file_path=removed_key)
+            return True
         return False
 
     async def remove_items_under(self, directory: str | Path) -> int:
@@ -392,6 +408,7 @@ class IndexingQueue:
 
                 now = time.time()
                 ready_items: list[QueueItem] = []
+                items_to_persist: list[QueueItem] = []
 
                 async with self._lock:
                     for item in self._items.values():
@@ -400,7 +417,7 @@ class IndexingQueue:
                             and now >= item.cooldown_expires_at
                         ):
                             item.status = QueueItemStatus.WAITING
-                            await self._save_item(item)
+                            items_to_persist.append(item)
 
                     ready_items = [
                         i for i in self._items.values()
@@ -411,7 +428,12 @@ class IndexingQueue:
                     # semaphore.
                     for item in ready_items:
                         item.status = QueueItemStatus.PROCESSING
-                        await self._save_item(item)
+                        items_to_persist.append(item)
+
+                # Persist status changes outside the lock to avoid blocking
+                # enqueue/remove operations during DB writes.
+                for item in items_to_persist:
+                    await self._save_item(item)
 
                 if ready_items:
                     tasks = [self._process_item(item) for item in ready_items]
@@ -444,20 +466,33 @@ class IndexingQueue:
             ))
 
             try:
+                timeout = self._config.file_processing_timeout
+
                 if item.action == QueueAction.DELETE:
-                    await self._pipeline.db.delete_file(item.file_path)
+                    await asyncio.wait_for(
+                        self._pipeline.db.delete_file(item.file_path),
+                        timeout=timeout,
+                    )
                 elif item.action == QueueAction.MOVE:
-                    await self._pipeline.db.delete_file(item.file_path)
-                    if item.dest_path:
-                        dest_file = File.from_path(Path(item.dest_path))
-                        if await self._pipeline.is_supported(dest_file):
-                            await self._pipeline.process_file(dest_file)
+                    async def _do_move() -> None:
+                        await self._pipeline.db.delete_file(item.file_path)
+                        if item.dest_path:
+                            dest_file = File.from_path(Path(item.dest_path))
+                            if await self._pipeline.is_supported(dest_file):
+                                await self._pipeline.process_file(dest_file)
+                    await asyncio.wait_for(_do_move(), timeout=timeout)
                 elif item.action == QueueAction.INDEX:
                     file = File.from_path(Path(item.file_path))
                     if await self._pipeline.is_supported(file):
-                        await self._pipeline.process_file(file)
+                        await asyncio.wait_for(
+                            self._pipeline.process_file(file),
+                            timeout=timeout,
+                        )
                 elif item.action == QueueAction.EMBED_FALLBACK:
-                    await self._pipeline.embed_fallback(item.file_path)
+                    await asyncio.wait_for(
+                        self._pipeline.embed_fallback(item.file_path),
+                        timeout=timeout,
+                    )
 
                 # Success — remove from queue
                 async with self._lock:

--- a/packages/cosma-backend/src/cosma_backend/queue/scheduler.py
+++ b/packages/cosma-backend/src/cosma_backend/queue/scheduler.py
@@ -230,32 +230,60 @@ class Scheduler:
     # Monitor loop
     # ------------------------------------------------------------------
 
+    async def evaluate_and_apply(self) -> bool:
+        """Collect fresh metrics, evaluate rules, and pause/resume the queue.
+
+        This is the primary entry point — it is called by the IndexingQueue
+        at each task boundary so pause/resume decisions react to real
+        instantaneous GPU/CPU/memory state without a fixed polling interval
+        (which would otherwise cause start/pause thrashing mid-task).
+
+        Returns True if conditions allow processing, False if paused.
+        """
+        async with self._config_lock:
+            enabled = self._config.enabled
+            has_rules = bool(self._config.rules)
+
+        if not (enabled and has_rules):
+            if not self._conditions_met:
+                self._conditions_met = True
+                self._queue.scheduler_resume()
+            return True
+
+        metrics = await self._collector.collect()
+        self._last_metrics = metrics
+
+        async with self._config_lock:
+            met = self._evaluate_rules(metrics)
+
+        if met != self._conditions_met:
+            self._conditions_met = met
+            if met:
+                self._queue.scheduler_resume()
+            else:
+                self._queue.scheduler_pause()
+        return met
+
     async def _monitor_loop(self) -> None:
+        """Backstop for time-based rules while the queue is idle.
+
+        Rule evaluation is primarily driven by the indexing queue at task
+        boundaries (see ``evaluate_and_apply``). This loop runs at a coarse
+        interval just to catch conditions that can change with no queue
+        activity — e.g. a ``time_window`` rule opening while nothing is
+        being processed.
+        """
         while True:
             try:
                 async with self._config_lock:
-                    enabled = self._config.enabled
-                    has_rules = bool(self._config.rules)
                     interval = self._config.check_interval_seconds
 
-                if enabled and has_rules:
-                    metrics = await self._collector.collect()
-                    self._last_metrics = metrics
-
-                    async with self._config_lock:
-                        met = self._evaluate_rules(metrics)
-
-                    if met != self._conditions_met:
-                        self._conditions_met = met
-                        if met:
-                            self._queue.scheduler_resume()
-                        else:
-                            self._queue.scheduler_pause()
-                else:
-                    # Scheduler disabled — make sure queue isn't scheduler-paused
-                    if not self._conditions_met:
-                        self._conditions_met = True
-                        self._queue.scheduler_resume()
+                # Only evaluate when the queue is idle — the queue's
+                # task-boundary hook handles the active-work case. This
+                # avoids competing with the hook and eliminates any
+                # mid-task metric polling.
+                if self._queue.queue_size == 0:
+                    await self.evaluate_and_apply()
 
                 await asyncio.sleep(interval)
             except asyncio.CancelledError:

--- a/packages/cosma-backend/src/cosma_backend/settings.py
+++ b/packages/cosma-backend/src/cosma_backend/settings.py
@@ -49,12 +49,15 @@ class LlamaCppConfig:
     n_gpu_layers: int = -1
     verbose: bool = False
     model_path: str = ""
-    repo_id: str = "unsloth/Qwen3.5-2B-GGUF"
+    # Standardized on Qwen3-VL-2B-Instruct: visual-input multimodal, small, fast.
+    # HuggingFace canonical model: Qwen/Qwen3-VL-2B-Instruct
+    # Ollama: qwen3-vl:2b-instruct
+    repo_id: str = "unsloth/Qwen3-VL-2B-Instruct-GGUF"
     filename: str = "*Q4_K_M.gguf"
     clip_model_path: str = ""
-    clip_repo_id: str = "unsloth/Qwen3.5-2B-GGUF"
+    clip_repo_id: str = "unsloth/Qwen3-VL-2B-Instruct-GGUF"
     clip_filename: str = "mmproj-F16.gguf"
-    chat_handler: str = "qwen3.5"
+    chat_handler: str = "qwen3-vl"
     enable_thinking: bool = False
     image_min_tokens: int = 1024
 
@@ -212,6 +215,7 @@ class QueueConfig:
     max_concurrency: int = 2
     max_retries: int = 3
     file_processing_timeout: int = 300  # seconds per file (5 min default)
+    gpu_memory_cap: float = 0.75  # fraction of GPU memory to use (0.0-1.0, default 75%)
 
 
 @dataclass

--- a/packages/cosma-backend/src/cosma_backend/settings.py
+++ b/packages/cosma-backend/src/cosma_backend/settings.py
@@ -211,6 +211,7 @@ class QueueConfig:
     initial_cooldown_seconds: int = 5
     max_concurrency: int = 2
     max_retries: int = 3
+    file_processing_timeout: int = 300  # seconds per file (5 min default)
 
 
 @dataclass

--- a/packages/cosma-backend/src/cosma_backend/settings.py
+++ b/packages/cosma-backend/src/cosma_backend/settings.py
@@ -111,7 +111,12 @@ class SchedulerRuleConfig:
 class SchedulerConfig:
     enabled: bool = False
     combine_mode: str = "ALL"
-    check_interval_seconds: int = 30
+    # The scheduler primarily evaluates rules BETWEEN tasks (see
+    # IndexingQueue._pre_task_hook). This interval is only used as a backstop
+    # for long-term conditions (e.g. time_window) that can change while the
+    # queue is idle. Short intervals cause unnecessary start/pause thrashing
+    # and mid-task metric polling, so keep it coarse.
+    check_interval_seconds: int = 60
     rules: list[SchedulerRuleConfig] = field(default_factory=list)
 
 

--- a/packages/cosma-backend/src/cosma_backend/summarizer/auto.py
+++ b/packages/cosma-backend/src/cosma_backend/summarizer/auto.py
@@ -126,8 +126,9 @@ class AutoSummarizer:
         }
 
         if self.preferred_provider in _provider_getters:
+            # The getter already checks is_available() and caches the result.
             provider = await _provider_getters[self.preferred_provider]()
-            if not provider or not await provider.is_available():
+            if not provider:
                 raise SummarizerError(
                     f"Summarizer provider '{self.preferred_provider}' is not available. "
                     f"Check that the required package is installed and configured."
@@ -135,7 +136,9 @@ class AutoSummarizer:
             logger.info("Attempting summarization", provider=type(provider).__name__)
             return await provider.summarize(file_metadata)
 
-        # "auto" mode: try all providers in priority order with fallback
+        # "auto" mode: try all providers in priority order with fallback.
+        # Each getter already checks is_available() internally and returns
+        # None when unavailable, so no second check is needed.
         providers = [
             await self._get_llamacpp_summarizer(),
             await self._get_ollama_summarizer(),
@@ -143,7 +146,7 @@ class AutoSummarizer:
         ]
 
         for provider in providers:
-            if provider and await provider.is_available():
+            if provider:
                 try:
                     logger.info("Attempting summarization", provider=type(provider).__name__)
                     return await provider.summarize(file_metadata)

--- a/packages/cosma-backend/src/cosma_backend/summarizer/base.py
+++ b/packages/cosma-backend/src/cosma_backend/summarizer/base.py
@@ -132,8 +132,8 @@ class BaseSummarizer(ABC):
             logger.info("Content chunked", num_chunks=len(chunks), avg_chunk_tokens=avg_chunk_tokens, max_chunk_sample=max_chunk_tokens)
 
         if len(chunks) > max_chunks:
-            logger.warning("Too many chunks, will not summarize", chunks=len(chunks), max_chunks=max_chunks)
-            raise RuntimeError("Too many chunks to summarize")
+            logger.warning("Too many chunks, processing first N only", chunks=len(chunks), max_chunks=max_chunks)
+            chunks = chunks[:max_chunks]
 
         return chunks
 

--- a/packages/cosma-backend/src/cosma_backend/summarizer/base.py
+++ b/packages/cosma-backend/src/cosma_backend/summarizer/base.py
@@ -112,6 +112,10 @@ class BaseSummarizer(ABC):
         chunks = await chunk_content(content, self.max_tokens, self.chunk_overlap, self.model)
         logger.info("Content chunked (noverify)", num_chunks=len(chunks))
 
+        if not chunks:
+            logger.warning("Chunking produced no output, returning content as single chunk")
+            return [content]
+
         max_chunks = self.config.max_chunks
 
         # Use fast estimation for chunk statistics (sample a few chunks for accurate check)

--- a/packages/cosma-backend/src/cosma_backend/summarizer/providers.py
+++ b/packages/cosma-backend/src/cosma_backend/summarizer/providers.py
@@ -4,6 +4,7 @@ Summarizer provider implementations: Ollama, Online (LiteLLM), and LlamaCpp.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from typing import Any, Optional, TYPE_CHECKING
@@ -370,11 +371,16 @@ class LlamaCppSummarizer(BaseSummarizer):
         text = self._format_content_with_context(chunk, chunk_num, total_chunks, filename)
         user_content = self._build_user_content(text, images)
 
-        response = self.llm.create_chat_completion(
-            messages=[
-                {"role": "system", "content": self._get_system_prompt(include_title=(chunk_num == 0))},
-                {"role": "user", "content": user_content},
-            ],
+        messages = [
+            {"role": "system", "content": self._get_system_prompt(include_title=(chunk_num == 0))},
+            {"role": "user", "content": user_content},
+        ]
+
+        # Offload synchronous llama.cpp inference to a thread so it doesn't
+        # block the async event loop (inference can take several seconds).
+        response = await asyncio.to_thread(
+            self.llm.create_chat_completion,
+            messages=messages,
             max_tokens=500,
             temperature=0.1,
             top_p=0.95,

--- a/packages/cosma-backend/src/cosma_backend/utils/pubsub.py
+++ b/packages/cosma-backend/src/cosma_backend/utils/pubsub.py
@@ -35,7 +35,11 @@ class Hub(Generic[T]):
     Generic pub/sub hub that broadcasts messages to all subscribers.
 
     Thread-safe for publishing; subscribers receive messages via asyncio.Queue.
+    Includes backpressure: subscriber queues are capped to prevent unbounded
+    memory growth from slow or disconnected clients.
     """
+
+    MAX_QUEUE_SIZE = 1000  # Maximum buffered messages per subscriber
 
     subscriptions: set[asyncio.Queue[T]]
 
@@ -43,9 +47,21 @@ class Hub(Generic[T]):
         self.subscriptions = set()
 
     def publish(self, message: T) -> None:
-        """Broadcast message to all subscribed queues."""
+        """Broadcast message to all subscribed queues.
+
+        Drops subscribers whose queue is full to prevent memory exhaustion.
+        """
+        dead_queues: list[asyncio.Queue[T]] = []
         for queue in self.subscriptions:
-            queue.put_nowait(message)
+            if queue.qsize() >= self.MAX_QUEUE_SIZE:
+                logger.warning("Subscriber queue full, dropping subscriber",
+                              queue_size=queue.qsize())
+                dead_queues.append(queue)
+            else:
+                queue.put_nowait(message)
+
+        for queue in dead_queues:
+            self.subscriptions.discard(queue)
 
 
 @contextmanager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cosma"
-version = "0.6.0"
+version = "0.7.0"
 requires-python = ">=3.12"
 description="Search engine for your files!"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- **LlamaCpp event loop blocking**: Wrapped sync `create_chat_completion()` in `asyncio.to_thread()` so inference doesn't freeze the entire server
- **Queue lock contention**: Moved all `_save_item()` DB writes outside `async with self._lock` using collect-then-persist pattern — enqueue/remove no longer blocked during DB I/O
- **Duplicate DB queries**: `_should_skip_file()` now returns the fetched record so `_has_file_changed()` reuses it instead of querying again (1 query per file instead of 2)
- **Embedder GPU/memory leak**: Added idle unload to lifecycle manager — embedder (~500MB+) now frees GPU after idle timeout and lazy-reloads on next use
- **Startup memory spike**: Replaced `fetchall("SELECT * FROM files")` + Python loop with SQL-level `DELETE WHERE NOT LIKE` for orphan cleanup
- **Hung file processing**: Added `asyncio.wait_for(timeout=300s)` on all pipeline operations — corrupted files can't permanently consume semaphore slots
- **Redundant Ollama network calls**: Removed double `is_available()` checks in auto summarizer (getter already caches the result)
- **Sync whisper unload**: Wrapped `unload_whisper_model()` in `asyncio.to_thread()` so GC + torch cache cleanup doesn't block the async loop

## Test plan
- [x] All 130 unit tests pass (1 skipped, same as before)
- [ ] Start backend, verify API responds at `localhost:60534/api/status/`
- [ ] Trigger file indexing, confirm no event loop blocking in logs
- [ ] Let backend idle 60+ seconds, verify embedder unloads in logs
- [ ] Kill and restart backend, verify queue items restore correctly