### PR TITLE
Isolate tests from real user config via app factory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,5 +58,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create ${{ github.ref_name }} \
-            --title "Release ${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
             --generate-notes

--- a/packages/cosma-backend/src/cosma_backend/__init__.py
+++ b/packages/cosma-backend/src/cosma_backend/__init__.py
@@ -1,14 +1,16 @@
-from .app import app as app
-from .app import run as run
+from .app import App as App, create_app as create_app, run as run
+
 
 def serve():
     import uvicorn
-    
+
+    app = create_app()
     uvicorn.run(
-        app, host="127.0.0.1",
-        port=60534,
+        app,
+        host=app.config["HOST"],
+        port=app.config["PORT"],
         log_level="info",
         # I can't find a way to gracefully shut down SSE connections,
         # so this bullshit will have to do for now
-        timeout_graceful_shutdown=5
+        timeout_graceful_shutdown=5,
     )

--- a/packages/cosma-backend/src/cosma_backend/api/files.py
+++ b/packages/cosma-backend/src/cosma_backend/api/files.py
@@ -11,7 +11,8 @@ from quart import Blueprint, current_app
 from quart_schema import validate_request, validate_response
 
 if TYPE_CHECKING:
-    from cosma_backend.app import app as current_app
+    from cosma_backend.app import App
+    current_app: App
 
 files_bp = Blueprint('files', __name__)
 

--- a/packages/cosma-backend/src/cosma_backend/api/index.py
+++ b/packages/cosma-backend/src/cosma_backend/api/index.py
@@ -16,7 +16,8 @@ from cosma_backend.models import File
 from cosma_backend.pipeline import Pipeline
 
 if TYPE_CHECKING:
-    from cosma_backend.app import app as current_app
+    from cosma_backend.app import App
+    current_app: App
 
 index_bp = Blueprint('index', __name__)
 

--- a/packages/cosma-backend/src/cosma_backend/api/queue.py
+++ b/packages/cosma-backend/src/cosma_backend/api/queue.py
@@ -11,7 +11,8 @@ from quart import Blueprint, current_app, request
 from quart_schema import validate_response
 
 if TYPE_CHECKING:
-    from cosma_backend.app import app as current_app
+    from cosma_backend.app import App
+    current_app: App
 
 queue_bp = Blueprint("queue", __name__)
 

--- a/packages/cosma-backend/src/cosma_backend/api/search.py
+++ b/packages/cosma-backend/src/cosma_backend/api/search.py
@@ -13,7 +13,8 @@ from quart_schema import validate_request, validate_response
 from cosma_backend.api.models import FileResponse
 
 if TYPE_CHECKING:
-    from cosma_backend.app import app as current_app
+    from cosma_backend.app import App
+    current_app: App
 
 search_bp = Blueprint('search', __name__)
 

--- a/packages/cosma-backend/src/cosma_backend/api/settings.py
+++ b/packages/cosma-backend/src/cosma_backend/api/settings.py
@@ -15,7 +15,8 @@ from quart import Blueprint, current_app, request
 from cosma_backend.logging import get_logger
 
 if TYPE_CHECKING:
-    from cosma_backend.app import app as current_app
+    from cosma_backend.app import App
+    current_app: App
 
 logger = get_logger(__name__)
 

--- a/packages/cosma-backend/src/cosma_backend/api/status.py
+++ b/packages/cosma-backend/src/cosma_backend/api/status.py
@@ -15,7 +15,8 @@ from quart_schema import validate_request, validate_response
 from cosma_backend.utils.pubsub import subscribe
 
 if TYPE_CHECKING:
-    from cosma_backend.app import app as current_app
+    from cosma_backend.app import App
+    current_app: App
 
 status_bp = Blueprint('status', __name__)
 

--- a/packages/cosma-backend/src/cosma_backend/api/updates.py
+++ b/packages/cosma-backend/src/cosma_backend/api/updates.py
@@ -18,7 +18,8 @@ from cosma_backend.utils.pubsub import subscribe
 from cosma_backend.utils.sse import ServerSentEvent, sse_comment
 
 if TYPE_CHECKING:
-    from cosma_backend.app import app as current_app
+    from cosma_backend.app import App
+    current_app: App
 
 updates_bp = Blueprint('updates', __name__)
 

--- a/packages/cosma-backend/src/cosma_backend/api/watch.py
+++ b/packages/cosma-backend/src/cosma_backend/api/watch.py
@@ -13,7 +13,8 @@ from quart_schema import validate_request, validate_response
 from cosma_backend.api.models import JobResponse
 
 if TYPE_CHECKING:
-    from cosma_backend.app import app as current_app
+    from cosma_backend.app import App
+    current_app: App
 
 watch_bp = Blueprint('watch', __name__)
 

--- a/packages/cosma-backend/src/cosma_backend/app.py
+++ b/packages/cosma-backend/src/cosma_backend/app.py
@@ -10,7 +10,7 @@ Main Quart web application that orchestrates all backend services:
 - Model Lifecycle: Automatic unloading of idle AI models
 
 Application lifecycle:
-1. App instance created, config loaded from env vars + TOML
+1. `create_app()` builds an App, loads config, registers blueprints + hooks
 2. `before_serving`: Initialize DB, services, start background tasks
 3. Request handling via API blueprints
 4. `after_serving`: Graceful shutdown of all services
@@ -18,8 +18,9 @@ Application lifecycle:
 
 import asyncio
 import datetime
+import os
 from pathlib import Path
-from typing import Coroutine
+from typing import Coroutine, Optional, Protocol
 
 from dotenv import load_dotenv
 from platformdirs import PlatformDirs
@@ -47,13 +48,28 @@ from cosma_backend.watcher import Watcher
 
 load_dotenv()
 
-import os
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 # Limit PyTorch MPS memory usage (set before torch is imported)
 os.environ.setdefault("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.75")
 
 configure_logging()
 logger = get_logger(__name__)
+
+
+class AppDirs(Protocol):
+    """Minimal subset of `platformdirs.PlatformDirs` used by the backend.
+
+    Any object exposing these three properties is accepted — this lets tests
+    pass a temp-directory shim without touching real user dirs.
+    """
+
+    @property
+    def user_config_dir(self) -> str: ...
+    @property
+    def user_data_dir(self) -> str: ...
+    @property
+    def user_log_dir(self) -> str: ...
+
 
 class App(Quart):
     """
@@ -80,18 +96,21 @@ class App(Quart):
     # Configuration
     filter_manager: FilterConfigManager  # Include/exclude patterns
     settings_manager: SettingsManager    # Persistent TOML settings
-    dirs: PlatformDirs                   # Platform-specific directories
+    dirs: AppDirs                        # Platform-specific directories
 
     # Background processing
     indexing_queue: IndexingQueue        # Async file processing queue
     scheduler: Scheduler                 # Conditional queue processing
     model_lifecycle: ModelLifecycleManager  # Auto-unload idle models
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, dirs: Optional[AppDirs] = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.updates_hub = Hub()
         self.jobs = set()
-        self.filter_manager = FilterConfigManager()
+        # Caller-supplied dirs take priority over the default PlatformDirs.
+        # Tests set this to a temp-directory shim so nothing touches
+        # ~/Library/Application Support/cosma.
+        self._dirs_override: Optional[AppDirs] = dirs
 
     def initialize_config(self) -> None:
         """
@@ -106,7 +125,10 @@ class App(Quart):
 
         # Bootstrap settings (env vars only, needed before app starts)
         self.config.setdefault("APP_NAME", "cosma")
-        self.dirs = PlatformDirs(self.config["APP_NAME"], ensure_exists=True)
+        if self._dirs_override is not None:
+            self.dirs = self._dirs_override
+        else:
+            self.dirs = PlatformDirs(self.config["APP_NAME"], ensure_exists=True)
         log_path = Path(self.dirs.user_log_dir) / "cosma-backend.log"
         configure_logging(log_path=log_path)
         logger = get_logger(__name__)
@@ -114,7 +136,9 @@ class App(Quart):
         self.config.setdefault("PORT", 60534)
         self.config.setdefault("DATABASE_PATH", Path(self.dirs.user_data_dir) / "app.db")
 
-        # Load persistent settings from TOML (model configs, queue settings, etc.)
+        # Filter and settings managers are bound to whichever dirs the app
+        # ended up with — real PlatformDirs in prod, temp shim in tests.
+        self.filter_manager = FilterConfigManager(dirs=self.dirs)
         self.settings_manager = SettingsManager(self.dirs)
         self.settings_manager.load()
 
@@ -140,166 +164,6 @@ class App(Quart):
         task.add_done_callback(remove_task_callback)
 
         return task
-        
-
-app = App(__name__)
-app.initialize_config()
-QuartSchema(app)
-
-# Register API blueprints
-app.register_blueprint(api_blueprint, url_prefix='/api')
-
-@app.before_serving
-async def initialize_services():
-    """Two-phase startup: API-ready first, heavy models load in background.
-
-    Phase 1 (blocking): DB + filter + services created (no model loading)
-           → API is reachable, frontend can connect
-    Phase 2 (background): Load embedding model + start indexing + watcher
-           → Search becomes available, then indexing starts
-    """
-    # ── Phase 1: Fast startup — get the API responding ──
-    logger.info("Phase 1: Initializing database and core services")
-    app.db = await db.connect(app.config['DATABASE_PATH'])
-
-    global_config = app.filter_manager.global_config
-    logger.info("Filter config loaded",
-                  mode=global_config.mode.value,
-                  include_count=len(global_config.include),
-                  config_path=str(global_config.config_path))
-
-    settings = app.settings_manager.settings
-
-    # Apply GPU memory cap from settings.
-    #
-    # IMPORTANT: the cap affects different backends differently:
-    #   * PyTorch / MPS (embedder, local whisper) — honors
-    #     PYTORCH_MPS_HIGH_WATERMARK_RATIO directly.
-    #   * llama.cpp (summarizer via llama-cpp-python) — uses its own Metal
-    #     backend. Memory usage is controlled by `summarizer.llamacpp.n_gpu_layers`
-    #     (negative = all layers on GPU, positive = N layers only). Metal
-    #     respects system memory pressure automatically.
-    #   * Ollama — runs as a separate process. Configure Ollama itself via
-    #     OLLAMA_NUM_GPU / OLLAMA_KEEP_ALIVE env vars before launching it;
-    #     this setting has no direct effect on an already-running Ollama server.
-    gpu_cap = settings.queue.gpu_memory_cap
-    if not (0.0 < gpu_cap <= 1.0):
-        logger.warning("Invalid gpu_memory_cap, falling back to 0.75",
-                      configured=gpu_cap)
-        gpu_cap = 0.75
-    os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = str(gpu_cap)
-
-    # Hint for any Ollama instance spawned in this environment
-    os.environ.setdefault("OLLAMA_KEEP_ALIVE", "5m")
-
-    logger.info(
-        "GPU memory cap applied",
-        gpu_cap=f"{gpu_cap:.0%}",
-        affects="torch (embedder, local whisper)",
-        note="llama.cpp uses n_gpu_layers; Ollama uses its own env config",
-    )
-
-    discoverer = Discoverer()
-    parser = FileParser(config=settings.parser)
-    summarizer = AutoSummarizer(config=settings.summarizer)
-
-    # Create embedder WITHOUT eager model loading — stays lazy
-    embedder = AutoEmbedder(config=settings.embedder, preferred_provider="lazy_local")
-
-    app.pipeline = Pipeline(
-        db=app.db, updates_hub=app.updates_hub,
-        parser=parser, discoverer=discoverer,
-        summarizer=summarizer, embedder=embedder,
-    )
-    app.searcher = HybridSearcher(db=app.db, embedder=embedder)
-
-    app.indexing_queue = IndexingQueue(
-        pipeline=app.pipeline, updates_hub=app.updates_hub,
-        config=settings.queue, db=app.db,
-    )
-    app.model_lifecycle = ModelLifecycleManager(
-        summarizer=summarizer,
-        idle_unload_seconds=settings.summarizer.idle_unload_seconds,
-        embedder=embedder,
-    )
-
-    logger.info("Phase 1 complete — API is ready")
-
-    # ── Phase 2: Background — load models and start indexing ──
-    # Start indexing services immediately (non-blocking async)
-    await app.indexing_queue.start()
-    app.scheduler = Scheduler(
-        queue=app.indexing_queue, updates_hub=app.updates_hub,
-        config=settings.scheduler,
-    )
-    app.indexing_queue.set_pre_task_hook(app.scheduler.evaluate_and_apply)
-    app.scheduler.start()
-    app.model_lifecycle.start()
-
-    app.watcher = Watcher(
-        db=app.db, pipeline=app.pipeline,
-        filter_manager=app.filter_manager,
-        indexing_queue=app.indexing_queue,
-    )
-
-    # Progress tracking for Phase 2 (0.0 → 1.0)
-    app._deferred_init_progress: float = 0.0
-    app._model_loading_done = asyncio.Event()
-
-    async def _model_loading_progress_updater():
-        """Smoothly increment progress from 10% → 78% over ~12 s while
-        the embedding model loads on a background thread."""
-        progress = 0.10
-        while not app._model_loading_done.is_set():
-            remaining = 0.78 - progress
-            if remaining > 0.01:
-                progress += remaining * 0.06
-                app._deferred_init_progress = progress
-            try:
-                await asyncio.wait_for(
-                    app._model_loading_done.wait(), timeout=0.3,
-                )
-                break
-            except asyncio.TimeoutError:
-                pass
-
-    async def _deferred_heavy_init():
-        """Load embedding model in a thread so it doesn't block the event loop.
-
-        This lets Uvicorn start accepting connections immediately after Phase 1
-        instead of waiting ~8s for the SentenceTransformer model to load.
-        Cancellation-safe: if SIGTERM arrives mid-load, the task is cancelled.
-        """
-        try:
-            app._deferred_init_progress = 0.05
-            logger.info("Phase 2: Loading embedding model...")
-            if embedder.preferred_provider in ("local", "lazy_local"):
-                embedder.preferred_provider = "local"
-                app._deferred_init_progress = 0.10
-                progress_task = asyncio.ensure_future(
-                    _model_loading_progress_updater(),
-                )
-                await asyncio.to_thread(embedder._eagerly_initialize_models)
-                app._model_loading_done.set()
-                await progress_task
-            app._deferred_init_progress = 0.80
-            logger.info("Embedding model loaded — search is ready")
-
-            logger.info("Running startup cleanup")
-            removed = await cleanup_excluded_files_on_startup(app.db, app.filter_manager)
-            if removed > 0:
-                logger.info("Cleanup complete", removed_files=removed)
-            app._deferred_init_progress = 0.90
-
-            await app.watcher.initialize_from_database()
-            app._deferred_init_progress = 1.0
-            logger.info("Phase 2 complete — indexing is ready")
-        except asyncio.CancelledError:
-            logger.info("Phase 2 cancelled (shutdown in progress)")
-        except Exception:
-            logger.exception("Error in deferred startup")
-
-    app._deferred_init_task = asyncio.ensure_future(_deferred_heavy_init())
 
 
 async def cleanup_excluded_files_on_startup(db: Database, filter_manager: FilterConfigManager) -> int:
@@ -379,91 +243,260 @@ async def cleanup_excluded_files_on_startup(db: Database, filter_manager: Filter
     return removed_count
 
 
-@app.after_serving
-async def handle_shutdown():
-    # Cancel Phase 2 if it's still running (e.g. model loading in thread).
-    # This prevents the shutdown from waiting on a slow model download.
-    deferred = getattr(app, "_deferred_init_task", None)
-    if deferred and not deferred.done():
-        logger.info("Shutdown: cancelling deferred startup")
-        deferred.cancel()
-        try:
-            await deferred
-        except (asyncio.CancelledError, Exception):
-            pass
+def create_app(dirs: Optional[AppDirs] = None) -> App:
+    """Build a fully-wired backend App.
 
-    logger.info("Shutdown: stopping lifecycle manager, scheduler, and indexing queue")
-    try:
-        await app.model_lifecycle.stop()
-    except Exception:
-        logger.exception("Error stopping model lifecycle manager")
-    try:
-        await app.scheduler.stop()
-    except Exception:
-        logger.exception("Error stopping scheduler")
-    try:
-        await app.indexing_queue.stop()
-    except Exception:
-        logger.exception("Error stopping indexing queue")
+    Args:
+        dirs: Optional override for platform directories. Production leaves this
+            unset and gets the default `PlatformDirs("cosma")`. Tests pass a
+            temp-directory shim so settings/logs/db stay isolated.
+    """
+    app = App(__name__, dirs=dirs)
+    app.initialize_config()
+    QuartSchema(app)
+    app.register_blueprint(api_blueprint, url_prefix='/api')
 
-    # Unload summarizer models — this is important for Ollama, which runs in a
-    # separate process and keeps the model pinned in GPU until explicitly told
-    # to release (via a request with keep_alive=0). Without this call, Ollama
-    # can hold 100% of GPU memory even after the backend quits.
-    logger.info("Shutdown: unloading summarizer models")
-    try:
-        summarizer = getattr(app.pipeline, "summarizer", None)
-        if summarizer is not None and hasattr(summarizer, "unload_models"):
-            await asyncio.wait_for(summarizer.unload_models(), timeout=3.0)
-    except asyncio.TimeoutError:
-        logger.warning("Summarizer unload timed out after 3s")
-    except Exception:
-        logger.exception("Error unloading summarizer models")
+    @app.before_serving
+    async def initialize_services():
+        """Two-phase startup: API-ready first, heavy models load in background.
 
-    # Unload Whisper if it was loaded
-    try:
-        from cosma_backend.parser.media import unload_whisper_model
-        unload_whisper_model()
-    except Exception:
-        logger.exception("Error unloading whisper model")
+        Phase 1 (blocking): DB + filter + services created (no model loading)
+               → API is reachable, frontend can connect
+        Phase 2 (background): Load embedding model + start indexing + watcher
+               → Search becomes available, then indexing starts
+        """
+        # ── Phase 1: Fast startup — get the API responding ──
+        logger.info("Phase 1: Initializing database and core services")
+        app.db = await db.connect(app.config['DATABASE_PATH'])
 
-    logger.info("Shutdown: closing DB")
-    try:
-        await app.db.close()
-    except Exception:
-        logger.exception("Error closing DB")
+        global_config = app.filter_manager.global_config
+        logger.info("Filter config loaded",
+                      mode=global_config.mode.value,
+                      include_count=len(global_config.include),
+                      config_path=str(global_config.config_path))
 
-    logger.info("Shutdown complete")
-    
+        settings = app.settings_manager.settings
 
-@app.before_request
-async def log_request():
-    request.start_time = datetime.datetime.now()
-    logger.info(
-        "Incoming request",
-        method=request.method,
-        path=request.path,
-        remote_addr=request.remote_addr,
-        user_agent=request.headers.get('User-Agent')
-    )
+        # Apply GPU memory cap from settings.
+        #
+        # IMPORTANT: the cap affects different backends differently:
+        #   * PyTorch / MPS (embedder, local whisper) — honors
+        #     PYTORCH_MPS_HIGH_WATERMARK_RATIO directly.
+        #   * llama.cpp (summarizer via llama-cpp-python) — uses its own Metal
+        #     backend. Memory usage is controlled by `summarizer.llamacpp.n_gpu_layers`
+        #     (negative = all layers on GPU, positive = N layers only). Metal
+        #     respects system memory pressure automatically.
+        #   * Ollama — runs as a separate process. Configure Ollama itself via
+        #     OLLAMA_NUM_GPU / OLLAMA_KEEP_ALIVE env vars before launching it;
+        #     this setting has no direct effect on an already-running Ollama server.
+        gpu_cap = settings.queue.gpu_memory_cap
+        if not (0.0 < gpu_cap <= 1.0):
+            logger.warning("Invalid gpu_memory_cap, falling back to 0.75",
+                          configured=gpu_cap)
+            gpu_cap = 0.75
+        os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = str(gpu_cap)
 
-@app.after_request
-async def log_response(response):
-    if hasattr(request, 'start_time'):
-        duration = (datetime.datetime.now() - request.start_time).total_seconds()
+        # Hint for any Ollama instance spawned in this environment
+        os.environ.setdefault("OLLAMA_KEEP_ALIVE", "5m")
+
         logger.info(
-            "Request completed",
+            "GPU memory cap applied",
+            gpu_cap=f"{gpu_cap:.0%}",
+            affects="torch (embedder, local whisper)",
+            note="llama.cpp uses n_gpu_layers; Ollama uses its own env config",
+        )
+
+        discoverer = Discoverer()
+        parser = FileParser(config=settings.parser)
+        summarizer = AutoSummarizer(config=settings.summarizer)
+
+        # Create embedder WITHOUT eager model loading — stays lazy
+        embedder = AutoEmbedder(config=settings.embedder, preferred_provider="lazy_local")
+
+        app.pipeline = Pipeline(
+            db=app.db, updates_hub=app.updates_hub,
+            parser=parser, discoverer=discoverer,
+            summarizer=summarizer, embedder=embedder,
+        )
+        app.searcher = HybridSearcher(db=app.db, embedder=embedder)
+
+        app.indexing_queue = IndexingQueue(
+            pipeline=app.pipeline, updates_hub=app.updates_hub,
+            config=settings.queue, db=app.db,
+        )
+        app.model_lifecycle = ModelLifecycleManager(
+            summarizer=summarizer,
+            idle_unload_seconds=settings.summarizer.idle_unload_seconds,
+            embedder=embedder,
+        )
+
+        logger.info("Phase 1 complete — API is ready")
+
+        # ── Phase 2: Background — load models and start indexing ──
+        # Start indexing services immediately (non-blocking async)
+        await app.indexing_queue.start()
+        app.scheduler = Scheduler(
+            queue=app.indexing_queue, updates_hub=app.updates_hub,
+            config=settings.scheduler,
+        )
+        app.indexing_queue.set_pre_task_hook(app.scheduler.evaluate_and_apply)
+        app.scheduler.start()
+        app.model_lifecycle.start()
+
+        app.watcher = Watcher(
+            db=app.db, pipeline=app.pipeline,
+            filter_manager=app.filter_manager,
+            indexing_queue=app.indexing_queue,
+        )
+
+        # Progress tracking for Phase 2 (0.0 → 1.0)
+        app._deferred_init_progress: float = 0.0
+        app._model_loading_done = asyncio.Event()
+
+        async def _model_loading_progress_updater():
+            """Smoothly increment progress from 10% → 78% over ~12 s while
+            the embedding model loads on a background thread."""
+            progress = 0.10
+            while not app._model_loading_done.is_set():
+                remaining = 0.78 - progress
+                if remaining > 0.01:
+                    progress += remaining * 0.06
+                    app._deferred_init_progress = progress
+                try:
+                    await asyncio.wait_for(
+                        app._model_loading_done.wait(), timeout=0.3,
+                    )
+                    break
+                except asyncio.TimeoutError:
+                    pass
+
+        async def _deferred_heavy_init():
+            """Load embedding model in a thread so it doesn't block the event loop.
+
+            This lets Uvicorn start accepting connections immediately after Phase 1
+            instead of waiting ~8s for the SentenceTransformer model to load.
+            Cancellation-safe: if SIGTERM arrives mid-load, the task is cancelled.
+            """
+            try:
+                app._deferred_init_progress = 0.05
+                logger.info("Phase 2: Loading embedding model...")
+                if embedder.preferred_provider in ("local", "lazy_local"):
+                    embedder.preferred_provider = "local"
+                    app._deferred_init_progress = 0.10
+                    progress_task = asyncio.ensure_future(
+                        _model_loading_progress_updater(),
+                    )
+                    await asyncio.to_thread(embedder._eagerly_initialize_models)
+                    app._model_loading_done.set()
+                    await progress_task
+                app._deferred_init_progress = 0.80
+                logger.info("Embedding model loaded — search is ready")
+
+                logger.info("Running startup cleanup")
+                removed = await cleanup_excluded_files_on_startup(app.db, app.filter_manager)
+                if removed > 0:
+                    logger.info("Cleanup complete", removed_files=removed)
+                app._deferred_init_progress = 0.90
+
+                await app.watcher.initialize_from_database()
+                app._deferred_init_progress = 1.0
+                logger.info("Phase 2 complete — indexing is ready")
+            except asyncio.CancelledError:
+                logger.info("Phase 2 cancelled (shutdown in progress)")
+            except Exception:
+                logger.exception("Error in deferred startup")
+
+        app._deferred_init_task = asyncio.ensure_future(_deferred_heavy_init())
+
+    @app.after_serving
+    async def handle_shutdown():
+        # Cancel Phase 2 if it's still running (e.g. model loading in thread).
+        # This prevents the shutdown from waiting on a slow model download.
+        deferred = getattr(app, "_deferred_init_task", None)
+        if deferred and not deferred.done():
+            logger.info("Shutdown: cancelling deferred startup")
+            deferred.cancel()
+            try:
+                await deferred
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        logger.info("Shutdown: stopping lifecycle manager, scheduler, and indexing queue")
+        try:
+            await app.model_lifecycle.stop()
+        except Exception:
+            logger.exception("Error stopping model lifecycle manager")
+        try:
+            await app.scheduler.stop()
+        except Exception:
+            logger.exception("Error stopping scheduler")
+        try:
+            await app.indexing_queue.stop()
+        except Exception:
+            logger.exception("Error stopping indexing queue")
+
+        # Unload summarizer models — this is important for Ollama, which runs in a
+        # separate process and keeps the model pinned in GPU until explicitly told
+        # to release (via a request with keep_alive=0). Without this call, Ollama
+        # can hold 100% of GPU memory even after the backend quits.
+        logger.info("Shutdown: unloading summarizer models")
+        try:
+            summarizer = getattr(app.pipeline, "summarizer", None)
+            if summarizer is not None and hasattr(summarizer, "unload_models"):
+                await asyncio.wait_for(summarizer.unload_models(), timeout=3.0)
+        except asyncio.TimeoutError:
+            logger.warning("Summarizer unload timed out after 3s")
+        except Exception:
+            logger.exception("Error unloading summarizer models")
+
+        # Unload Whisper if it was loaded
+        try:
+            from cosma_backend.parser.media import unload_whisper_model
+            unload_whisper_model()
+        except Exception:
+            logger.exception("Error unloading whisper model")
+
+        logger.info("Shutdown: closing DB")
+        try:
+            await app.db.close()
+        except Exception:
+            logger.exception("Error closing DB")
+
+        logger.info("Shutdown complete")
+
+    @app.before_request
+    async def log_request():
+        request.start_time = datetime.datetime.now()
+        logger.info(
+            "Incoming request",
             method=request.method,
             path=request.path,
-            status_code=response.status_code,
-            duration_seconds=duration
+            remote_addr=request.remote_addr,
+            user_agent=request.headers.get('User-Agent')
         )
-    return response
+
+    @app.after_request
+    async def log_response(response):
+        if hasattr(request, 'start_time'):
+            duration = (datetime.datetime.now() - request.start_time).total_seconds()
+            logger.info(
+                "Request completed",
+                method=request.method,
+                path=request.path,
+                status_code=response.status_code,
+                duration_seconds=duration
+            )
+        return response
+
+    return app
 
 
 # ====== Application Entry Point ======
 
 def run() -> None:
+    """Production entrypoint: build the default app and serve it with Quart's
+    dev server. The uvicorn-based path lives in `cosma_backend.serve`."""
+    app = create_app()
     app.run(
         host=app.config['HOST'],
         port=app.config['PORT'],

--- a/packages/cosma-backend/src/cosma_backend/filter/filter_config.py
+++ b/packages/cosma-backend/src/cosma_backend/filter/filter_config.py
@@ -14,7 +14,7 @@ import shutil
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Protocol
 
 from platformdirs import PlatformDirs
 
@@ -26,8 +26,28 @@ logger = get_logger(__name__)
 GLOBAL_CONFIG_FILENAME = "filter.json"  # Global config in app data dir
 LOCAL_CONFIG_FILENAME = ".cosmaconfig"   # Per-folder config
 
-# App directories (same as used by app.py and tui)
-APP_DIRS = PlatformDirs("cosma", ensure_exists=True)
+
+class _AppDirs(Protocol):
+    """Subset of platformdirs.PlatformDirs actually consumed by this module."""
+
+    @property
+    def user_config_dir(self) -> str: ...
+    @property
+    def user_data_dir(self) -> str: ...
+
+
+# Lazy default — only instantiated when a caller actually needs the real
+# user-config path. Creating `PlatformDirs(..., ensure_exists=True)` at import
+# time would materialize `~/Library/Application Support/cosma/` even during
+# test runs, which breaks isolation.
+_default_app_dirs: Optional[PlatformDirs] = None
+
+
+def _get_default_app_dirs() -> PlatformDirs:
+    global _default_app_dirs
+    if _default_app_dirs is None:
+        _default_app_dirs = PlatformDirs("cosma", ensure_exists=True)
+    return _default_app_dirs
 
 
 class FilterMode(str, Enum):
@@ -477,36 +497,45 @@ class FilterConfig:
             return False
 
     @classmethod
-    def get_default_global_path(cls) -> Path:
+    def get_default_global_path(cls, dirs: Optional[_AppDirs] = None) -> Path:
         """Get the default path for global config.
+
+        Args:
+            dirs: Override the app directories (tests pass a temp shim).
+                When None, falls back to the real PlatformDirs for "cosma".
 
         Returns path in app config directory:
         - macOS: ~/Library/Application Support/cosma/filter.json
         - Linux: ~/.config/cosma/filter.json
         - Windows: C:/Users/<user>/AppData/Local/cosma/filter.json
         """
-        return Path(APP_DIRS.user_config_dir) / GLOBAL_CONFIG_FILENAME
+        app_dirs = dirs if dirs is not None else _get_default_app_dirs()
+        return Path(app_dirs.user_config_dir) / GLOBAL_CONFIG_FILENAME
 
     @classmethod
-    def _migrate_from_data_dir(cls) -> None:
+    def _migrate_from_data_dir(cls, dirs: Optional[_AppDirs] = None) -> None:
         """Migrate filter config from user_data_dir to user_config_dir if needed."""
-        old_path = Path(APP_DIRS.user_data_dir) / GLOBAL_CONFIG_FILENAME
-        new_path = cls.get_default_global_path()
+        app_dirs = dirs if dirs is not None else _get_default_app_dirs()
+        old_path = Path(app_dirs.user_data_dir) / GLOBAL_CONFIG_FILENAME
+        new_path = cls.get_default_global_path(dirs=app_dirs)
         if old_path.exists() and not new_path.exists():
             new_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(old_path), str(new_path))
             logger.info("Migrated filter config", old=str(old_path), new=str(new_path))
 
     @classmethod
-    def load_global(cls) -> FilterConfig:
+    def load_global(cls, dirs: Optional[_AppDirs] = None) -> FilterConfig:
         """
         Load global filter config, creating default if not exists.
+
+        Args:
+            dirs: Override the app directories (tests pass a temp shim).
 
         Returns:
             FilterConfig instance (default if file doesn't exist)
         """
-        cls._migrate_from_data_dir()
-        global_path = cls.get_default_global_path()
+        cls._migrate_from_data_dir(dirs=dirs)
+        global_path = cls.get_default_global_path(dirs=dirs)
 
         config = cls.load_from_file(global_path)
         if config is not None:
@@ -557,7 +586,12 @@ class FilterConfig:
         return config
 
     @classmethod
-    def load_for_directory(cls, directory: Path, global_config: Optional[FilterConfig] = None) -> FilterConfig:
+    def load_for_directory(
+        cls,
+        directory: Path,
+        global_config: Optional[FilterConfig] = None,
+        dirs: Optional[_AppDirs] = None,
+    ) -> FilterConfig:
         """
         Load merged config for a specific directory.
 
@@ -568,13 +602,14 @@ class FilterConfig:
         Args:
             directory: Directory to load config for
             global_config: Optional pre-loaded global config
+            dirs: Override the app directories (only used when global_config is None)
 
         Returns:
             Merged FilterConfig
         """
         # Load global config if not provided
         if global_config is None:
-            global_config = cls.load_global()
+            global_config = cls.load_global(dirs=dirs)
 
         # Check for per-folder config (.cosmaconfig in the watched directory)
         folder_config_path = directory / LOCAL_CONFIG_FILENAME
@@ -671,7 +706,8 @@ class FilterConfigManager:
     Caches loaded configs and handles reloading on config file changes.
     """
 
-    def __init__(self):
+    def __init__(self, dirs: Optional[_AppDirs] = None):
+        self._dirs = dirs
         self._global_config: Optional[FilterConfig] = None
         self._directory_configs: dict[Path, FilterConfig] = {}
 
@@ -679,12 +715,12 @@ class FilterConfigManager:
     def global_config(self) -> FilterConfig:
         """Get the global config, loading if necessary."""
         if self._global_config is None:
-            self._global_config = FilterConfig.load_global()
+            self._global_config = FilterConfig.load_global(dirs=self._dirs)
         return self._global_config
 
     def reload_global(self) -> FilterConfig:
         """Force reload of global config."""
-        self._global_config = FilterConfig.load_global()
+        self._global_config = FilterConfig.load_global(dirs=self._dirs)
         # Invalidate all directory configs since they depend on global
         self._directory_configs.clear()
         return self._global_config

--- a/packages/cosma-backend/tests/conftest.py
+++ b/packages/cosma-backend/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import tempfile
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncGenerator, Generator
@@ -13,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 from cosma_backend.db.database import Database
 from cosma_backend.models.file import File
 from cosma_backend.models.status import ProcessingStatus
-from cosma_backend.app import App
+from cosma_backend.app import App, create_app
 from cosma_backend.discoverer import Discoverer
 from cosma_backend.parser import FileParser
 from cosma_backend.summarizer import AutoSummarizer
@@ -107,17 +108,46 @@ def sample_file_data() -> dict:
     }
 
 
+@dataclass
+class _TestAppDirs:
+    """Test stand-in for PlatformDirs.
+
+    Exposes only the three properties cosma-backend reads (user_config_dir,
+    user_data_dir, user_log_dir). Pointing every dir at a temp directory is
+    what keeps tests from touching ~/Library/Application Support/cosma.
+    """
+    user_config_dir: str
+    user_data_dir: str
+    user_log_dir: str
+
+
+@pytest.fixture
+def isolated_app_dirs(tmp_path: Path) -> _TestAppDirs:
+    """Build per-test PlatformDirs pointing at a temp directory."""
+    config_dir = tmp_path / "config"
+    data_dir = tmp_path / "data"
+    log_dir = tmp_path / "logs"
+    for d in (config_dir, data_dir, log_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    return _TestAppDirs(
+        user_config_dir=str(config_dir),
+        user_data_dir=str(data_dir),
+        user_log_dir=str(log_dir),
+    )
+
+
 @pytest_asyncio.fixture
-async def app_instance() -> AsyncGenerator[App, None]:
-    """Create a test instance of the Quart app using the real app with routes."""
-    # Import the actual app from app.py which has all routes registered
-    from cosma_backend.app import app as real_app
+async def app_instance(isolated_app_dirs: _TestAppDirs) -> AsyncGenerator[App, None]:
+    """Build a fresh backend App per test, isolated from the real user dirs.
 
-    # Override config for testing
-    real_app.config["TESTING"] = True
-    real_app.config["DATABASE_PATH"] = ":memory:"
+    Uses `create_app(dirs=...)` so settings/filter/log/db paths all resolve
+    into the tmp directory. No port is bound — callers use `app.test_client()`.
+    """
+    app = create_app(dirs=isolated_app_dirs)
+    app.config["TESTING"] = True
+    app.config["DATABASE_PATH"] = ":memory:"
 
-    yield real_app
+    yield app
 
 
 @pytest_asyncio.fixture

--- a/packages/cosma-backend/tests/integration/test_pipeline.py
+++ b/packages/cosma-backend/tests/integration/test_pipeline.py
@@ -105,7 +105,7 @@ class TestPipeline:
         await test_pipeline.db.upsert_file(file_obj)
         
         # Check if file should be skipped
-        should_skip = await test_pipeline._should_skip_file(file_obj)
+        should_skip, _saved = await test_pipeline._should_skip_file(file_obj)
         assert should_skip is True
 
     async def test_should_process_modified_file(self, test_pipeline: Pipeline, temp_file_dir: Path):
@@ -124,7 +124,7 @@ class TestPipeline:
         current_file_obj = File.from_path(test_file)
         
         # Check if file should be skipped (it shouldn't be)
-        should_skip = await test_pipeline._should_skip_file(current_file_obj)
+        should_skip, _saved = await test_pipeline._should_skip_file(current_file_obj)
         assert should_skip is False
 
     async def test_has_file_changed_by_hash(self, test_pipeline: Pipeline, temp_file_dir: Path):

--- a/packages/cosma-backend/tests/unit/test_settings.py
+++ b/packages/cosma-backend/tests/unit/test_settings.py
@@ -4,7 +4,6 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from platformdirs import PlatformDirs
 
 from cosma_backend.settings import (
     SettingsManager,
@@ -112,10 +111,13 @@ class TestSettingsManager:
         return config_dir
 
     @pytest.fixture
-    def manager(self, temp_config_dir):
-        """Create a SettingsManager with a temp config dir."""
-        dirs = PlatformDirs("cosma-test", ensure_exists=True)
-        mgr = SettingsManager(dirs)
+    def manager(self, temp_config_dir, isolated_app_dirs):
+        """Create a SettingsManager with a temp config dir.
+
+        Uses the shared `isolated_app_dirs` shim so nothing escapes to the real
+        user dirs even before `_toml_path` is overridden.
+        """
+        mgr = SettingsManager(isolated_app_dirs)
         # Override the TOML path to use temp dir
         mgr._toml_path = temp_config_dir / "settings.toml"
         return mgr

--- a/skills/cosma-backend-dev.md
+++ b/skills/cosma-backend-dev.md
@@ -79,11 +79,12 @@ current_app.updates_hub.publish(
 ```python
 # tests/unit/test_myfeature.py
 import pytest
-from cosma_backend.app import app
 
 @pytest.fixture
-def client():
-    return app.test_client()
+def client(app_instance):
+    # `app_instance` is a conftest fixture that builds an isolated App via
+    # `create_app(dirs=...)` so tests don't touch the real user config.
+    return app_instance.test_client()
 
 @pytest.mark.asyncio
 async def test_do_something(client):

--- a/uv.lock
+++ b/uv.lock
@@ -410,7 +410,7 @@ wheels = [
 
 [[package]]
 name = "cosma"
-version = "0.6.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "click-help-colors" },
@@ -450,7 +450,7 @@ dev = [
 
 [[package]]
 name = "cosma-backend"
-version = "0.5.0"
+version = "0.7.1"
 source = { editable = "packages/cosma-backend" }
 dependencies = [
     { name = "asqlite" },


### PR DESCRIPTION
## Summary

- `cosma_backend/app.py` no longer creates a module-level `App` at import. A new `create_app(dirs=None)` factory builds the app, registers blueprints, and wires all `before_/after_` hooks. Prod `run()` / `serve()` call it with no args; tests pass a tmp-dir `PlatformDirs` shim.
- `filter/filter_config.py` no longer materializes `PlatformDirs("cosma", ensure_exists=True)` at import time. `FilterConfigManager(dirs=...)` and `FilterConfig.load_global(dirs=...)` accept an override; default falls back to a lazy real `PlatformDirs`.
- `tests/conftest.py` defines an `isolated_app_dirs` fixture + `_TestAppDirs` shim so every test gets its own tmp directory for config/data/logs. No test reads or writes `~/Library/Application Support/cosma` anymore.
- Fix two stale pipeline tests (`test_should_skip_file_already_processed`, `test_should_process_modified_file`) that still expected `_should_skip_file` to return a bool after it was changed to return `(bool, File | None)`.

## Test plan

- [x] `uv run pytest` — 189 passed, 7 skipped
- [x] `grep` test output for `Library/Application Support` and `Loaded settings from TOML` — no matches
- [x] `uv run python -c "from cosma_backend import create_app; app = create_app()"` — prod path still loads real settings TOML

🤖 Generated with [Claude Code](https://claude.com/claude-code)